### PR TITLE
feat(seo): global canonical tags and breadcrumb structured data

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -214,7 +214,8 @@
           "subtitle": "Latest accepted articles",
           "see": "See all accepted articles"
         }
-      }
+      },
+      "description": "Academic journal hosted on Episciences"
     },
     "articles": {
       "title": "Articles",
@@ -228,7 +229,8 @@
         "preprint": "Preprint",
         "report": "Report",
         "software": "Software"
-      }
+      },
+      "description": "Browse all articles published in this journal"
     },
     "articleDetails": {
       "title": "Article",
@@ -383,20 +385,24 @@
         "openPDF": "Open PDF",
         "pdfDisplayTitle": "PDF Display",
         "pdfDisplayMessage": "The PDF cannot be displayed directly. Click the button below to open it in a new tab or download it."
-      }
+      },
+      "description": "Article details, abstract and full text"
     },
     "articlesAccepted": {
-      "title": "To be published"
+      "title": "To be published",
+      "description": "Articles accepted for publication and forthcoming issues"
     },
     "search": {
-      "title": "Search"
+      "title": "Search",
+      "description": "Search articles, authors and volumes"
     },
     "volumes": {
       "title": "Volumes",
       "types": {
         "specialIssues": "Special issues",
         "proceedings": "Proceedings"
-      }
+      },
+      "description": "Browse all volumes and special issues of this journal"
     },
     "volumeDetails": {
       "title": "Volume",
@@ -415,28 +421,34 @@
         "lookAtSelectedVolume": "Look at the selected volume",
         "lookAtSelectedIssue": "Look at the selected issue",
         "lookAtSelectedProceedings": "Look at the selected proceedings"
-      }
+      },
+      "description": "Volume details and articles"
     },
     "sections": {
       "title": "Sections",
       "totalArticles": "Total Articles",
       "articlesInSection": "Articles in this Section",
       "noArticlesTitle": "No Articles Found",
-      "noArticlesMessage": "This section currently has no articles."
+      "noArticlesMessage": "This section currently has no articles.",
+      "description": "Browse all sections of this journal"
     },
     "sectionDetails": {
-      "title": "Section"
+      "title": "Section",
+      "description": "Section details and related articles"
     },
     "authors": {
       "title": "Authors",
       "searchName": "search a name",
-      "others": "Others"
+      "others": "Others",
+      "description": "Browse all authors who have published in this journal"
     },
     "about": {
-      "title": "The journal"
+      "title": "The journal",
+      "description": "Discover the mission, history and editorial team of this journal"
     },
     "news": {
-      "title": "News"
+      "title": "News",
+      "description": "Latest news and announcements from this journal"
     },
     "statistics": {
       "title": "Statistics",
@@ -460,7 +472,8 @@
         "beingPublished": "Being published",
         "accepted": "Accepted articles",
         "other-status": "Other status"
-      }
+      },
+      "description": "Publication statistics and metrics"
     },
     "boards": {
       "title": "Boards",
@@ -484,38 +497,47 @@
         "advisoryBoard": "Advisory board member",
         "member": "Member",
         "formerMember": "Former member"
-      }
+      },
+      "description": "Editorial boards and committees"
     },
     "forAuthors": {
-      "title": "For authors"
+      "title": "For authors",
+      "description": "Guidelines and resources for authors submitting to this journal"
     },
     "acknowledgements": {
       "title": "Acknowledgements",
-      "noContent": "No acknowledgements available for this journal."
+      "noContent": "No acknowledgements available for this journal.",
+      "description": "Acknowledgements and thanks from this journal"
     },
     "indexing": {
       "title": "Indexing",
-      "noContent": "No indexing information available for this journal."
+      "noContent": "No indexing information available for this journal.",
+      "description": "Indexing and abstracting databases for this journal"
     },
     "ethicalCharter": {
       "title": "Ethical Charter",
-      "noContent": "No ethical charter available for this journal."
+      "noContent": "No ethical charter available for this journal.",
+      "description": "Ethical principles and publication standards"
     },
     "forReviewers": {
       "title": "For Reviewers",
-      "noContent": "No information for reviewers available for this journal."
+      "noContent": "No information for reviewers available for this journal.",
+      "description": "Information and resources for reviewers"
     },
     "forEditors": {
       "title": "For Editors",
-      "noContent": "No information for editors available for this journal."
+      "noContent": "No information for editors available for this journal.",
+      "description": "Information and resources for editors"
     },
     "forConferenceOrganisers": {
       "title": "For Conference Organisers",
-      "noContent": "No information for conference organisers available for this journal."
+      "noContent": "No information for conference organisers available for this journal.",
+      "description": "Information and resources for conference organisers"
     },
     "proposingSpecialIssues": {
       "title": "Proposing Special Issues",
-      "noContent": "No information about proposing special issues available for this journal."
+      "noContent": "No information about proposing special issues available for this journal.",
+      "description": "Guidelines for proposing special issues"
     },
     "accessibility": {
       "title": "Accessibility",
@@ -523,7 +545,8 @@
       "noContent": "Content not found."
     },
     "credits": {
-      "title": "Credits"
+      "title": "Credits",
+      "description": "Credits and legal notices"
     }
   }
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -214,7 +214,8 @@
           "subtitle": "Últimos artículos aceptados",
           "see": "Ver todos los artículos aceptados"
         }
-      }
+      },
+      "description": "Revista académica alojada en Episciences"
     },
     "articles": {
       "title": "Artículos",
@@ -228,7 +229,8 @@
         "preprint": "Preimpresión",
         "report": "Informe",
         "software": "Software"
-      }
+      },
+      "description": "Explore todos los artículos publicados en esta revista"
     },
     "articleDetails": {
       "title": "Artículo",
@@ -383,20 +385,24 @@
         "openPDF": "Abrir PDF",
         "pdfDisplayTitle": "Visualización del PDF",
         "pdfDisplayMessage": "El PDF no se puede mostrar directamente. Haga clic en el botón de abajo para abrirlo en una nueva pestaña o descargarlo."
-      }
+      },
+      "description": "Detalles del artículo, resumen y texto completo"
     },
     "articlesAccepted": {
-      "title": "Próximas publicaciones"
+      "title": "Próximas publicaciones",
+      "description": "Artículos aceptados para publicación y próximas publicaciones"
     },
     "search": {
-      "title": "Buscar"
+      "title": "Buscar",
+      "description": "Buscar artículos, autores y volúmenes"
     },
     "volumes": {
       "title": "Volúmenes",
       "types": {
         "specialIssues": "Números especiales",
         "proceedings": "Actas de congresos"
-      }
+      },
+      "description": "Explore todos los volúmenes y números especiales de esta revista"
     },
     "volumeDetails": {
       "title": "Volumen",
@@ -415,28 +421,34 @@
         "lookAtSelectedVolume": "Consultar el volumen seleccionado",
         "lookAtSelectedIssue": "Consultar el número seleccionado",
         "lookAtSelectedProceedings": "Consultar las actas seleccionadas"
-      }
+      },
+      "description": "Detalles del volumen y artículos"
     },
     "sections": {
       "title": "Secciones",
       "totalArticles": "Total de artículos",
       "articlesInSection": "Artículos en esta sección",
       "noArticlesTitle": "No se encontraron artículos",
-      "noArticlesMessage": "Esta sección no tiene artículos actualmente."
+      "noArticlesMessage": "Esta sección no tiene artículos actualmente.",
+      "description": "Explore todas las secciones de esta revista"
     },
     "sectionDetails": {
-      "title": "Sección"
+      "title": "Sección",
+      "description": "Detalles de la sección y artículos relacionados"
     },
     "authors": {
       "title": "Autores",
       "searchName": "buscar un nombre",
-      "others": "Otros"
+      "others": "Otros",
+      "description": "Explore todos los autores que han publicado en esta revista"
     },
     "about": {
-      "title": "La revista"
+      "title": "La revista",
+      "description": "Descubra la misión, historia y equipo editorial de esta revista"
     },
     "news": {
-      "title": "Noticias"
+      "title": "Noticias",
+      "description": "Últimas noticias y anuncios de esta revista"
     },
     "statistics": {
       "title": "Estadísticas",
@@ -460,7 +472,8 @@
         "beingPublished": "En curso de publicación",
         "accepted": "Artículos aceptados",
         "other-status": "Otro estado"
-      }
+      },
+      "description": "Estadísticas y métricas de publicación"
     },
     "boards": {
       "title": "Comités",
@@ -484,38 +497,47 @@
         "advisoryBoard": "Miembro del comité consultivo",
         "member": "Miembro",
         "formerMember": "Antiguo miembro"
-      }
+      },
+      "description": "Comités editoriales"
     },
     "forAuthors": {
-      "title": "Para autores"
+      "title": "Para autores",
+      "description": "Directrices y recursos para autores que envían a esta revista"
     },
     "acknowledgements": {
       "title": "Agradecimientos",
-      "noContent": "No hay agradecimientos disponibles para esta revista."
+      "noContent": "No hay agradecimientos disponibles para esta revista.",
+      "description": "Agradecimientos de esta revista"
     },
     "indexing": {
       "title": "Indexación",
-      "noContent": "No hay información de indexación disponible para esta revista."
+      "noContent": "No hay información de indexación disponible para esta revista.",
+      "description": "Bases de datos de indexación de esta revista"
     },
     "ethicalCharter": {
       "title": "Carta ética",
-      "noContent": "No hay carta ética disponible para esta revista."
+      "noContent": "No hay carta ética disponible para esta revista.",
+      "description": "Principios éticos y normas de publicación"
     },
     "forReviewers": {
       "title": "Para revisores",
-      "noContent": "No hay información para revisores disponible para esta revista."
+      "noContent": "No hay información para revisores disponible para esta revista.",
+      "description": "Información y recursos para revisores"
     },
     "forEditors": {
       "title": "Para editores",
-      "noContent": "No hay información para editores disponible para esta revista."
+      "noContent": "No hay información para editores disponible para esta revista.",
+      "description": "Información y recursos para editores"
     },
     "forConferenceOrganisers": {
       "title": "Para organizadores de congresos",
-      "noContent": "No hay información para organizadores de congresos disponible para esta revista."
+      "noContent": "No hay información para organizadores de congresos disponible para esta revista.",
+      "description": "Información y recursos para organizadores de congresos"
     },
     "proposingSpecialIssues": {
       "title": "Propuesta de monográficos",
-      "noContent": "No hay información sobre la propuesta de monográficos disponible para esta revista."
+      "noContent": "No hay información sobre la propuesta de monográficos disponible para esta revista.",
+      "description": "Directrices para proponer monográficos"
     },
     "accessibility": {
       "title": "Accesibilidad",
@@ -523,7 +545,8 @@
       "noContent": "Contenido no encontrado."
     },
     "credits": {
-      "title": "Créditos"
+      "title": "Créditos",
+      "description": "Créditos y avisos legales"
     },
     "common": {
       "noContent": "No hay contenido disponible para esta revista."

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -221,7 +221,8 @@
           "subtitle": "Derniers articles acceptés",
           "see": "Voir tous les articles acceptés"
         }
-      }
+      },
+      "description": "Revue académique hébergée sur Episciences"
     },
     "articles": {
       "title": "Articles",
@@ -235,7 +236,8 @@
         "preprint": "Pré-publication",
         "report": "Rapport",
         "software": "Logiciel"
-      }
+      },
+      "description": "Parcourez tous les articles publiés dans cette revue"
     },
     "articleDetails": {
       "title": "Article",
@@ -390,20 +392,24 @@
         "openPDF": "Ouvrir le PDF",
         "pdfDisplayTitle": "Affichage du PDF",
         "pdfDisplayMessage": "Le PDF ne peut pas être affiché directement. Cliquez sur le bouton ci-dessous pour l'ouvrir dans un nouvel onglet ou le télécharger."
-      }
+      },
+      "description": "Détails de l'article, résumé et texte intégral"
     },
     "articlesAccepted": {
-      "title": "À paraître"
+      "title": "À paraître",
+      "description": "Articles acceptés pour publication et numéros à paraître"
     },
     "search": {
-      "title": "Rechercher"
+      "title": "Rechercher",
+      "description": "Rechercher des articles, auteurs et volumes"
     },
     "volumes": {
       "title": "Volumes",
       "types": {
         "specialIssues": "Volumes spéciaux",
         "proceedings": "Actes de conférences"
-      }
+      },
+      "description": "Parcourez tous les volumes et numéros spéciaux de cette revue"
     },
     "volumeDetails": {
       "title": "Volume",
@@ -422,28 +428,34 @@
         "lookAtSelectedVolume": "Consulter le volume sélectionné",
         "lookAtSelectedIssue": "Consulter le volume spécial sélectionné",
         "lookAtSelectedProceedings": "Consulter l'acte de conférence sélectionné"
-      }
+      },
+      "description": "Détails du volume et articles"
     },
     "sections": {
       "title": "Rubriques",
       "totalArticles": "Total des Articles",
       "articlesInSection": "Articles de cette Section",
       "noArticlesTitle": "Aucun Article Trouvé",
-      "noArticlesMessage": "Cette section n'a actuellement aucun article."
+      "noArticlesMessage": "Cette section n'a actuellement aucun article.",
+      "description": "Parcourez toutes les rubriques de cette revue"
     },
     "sectionDetails": {
-      "title": "Rubrique"
+      "title": "Rubrique",
+      "description": "Détails de la rubrique et articles associés"
     },
     "authors": {
       "title": "Auteurs/Autrices",
       "searchName": "rechercher un nom",
-      "others": "Autres"
+      "others": "Autres",
+      "description": "Parcourez tous les auteurs ayant publié dans cette revue"
     },
     "about": {
-      "title": "La revue"
+      "title": "La revue",
+      "description": "Découvrez la mission, l'histoire et l'équipe éditoriale de cette revue"
     },
     "news": {
-      "title": "Actualités"
+      "title": "Actualités",
+      "description": "Dernières actualités et annonces de cette revue"
     },
     "statistics": {
       "title": "Statistiques",
@@ -467,7 +479,8 @@
         "beingPublished": "En cours de publication",
         "accepted": "Articles acceptés",
         "other-status": "Autre statut"
-      }
+      },
+      "description": "Statistiques et métriques de publication"
     },
     "boards": {
       "title": "Comités",
@@ -491,38 +504,47 @@
         "advisoryBoard": "Membre du comité consultatif",
         "member": "Membre",
         "formerMember": "Ancien/Ancienne membre"
-      }
+      },
+      "description": "Comités éditoriaux"
     },
     "forAuthors": {
-      "title": "Pour les auteurs/autrices"
+      "title": "Pour les auteurs/autrices",
+      "description": "Directives et ressources pour les auteurs soumettant à cette revue"
     },
     "acknowledgements": {
       "title": "Remerciements",
-      "noContent": "Aucun remerciement disponible pour cette revue."
+      "noContent": "Aucun remerciement disponible pour cette revue.",
+      "description": "Remerciements de cette revue"
     },
     "indexing": {
       "title": "Indexation",
-      "noContent": "Aucune information de référencement disponible pour cette revue."
+      "noContent": "Aucune information de référencement disponible pour cette revue.",
+      "description": "Bases de données d'indexation de cette revue"
     },
     "ethicalCharter": {
       "title": "Charte éthique",
-      "noContent": "Aucune charte éthique disponible pour cette revue."
+      "noContent": "Aucune charte éthique disponible pour cette revue.",
+      "description": "Principes éthiques et normes de publication"
     },
     "forReviewers": {
       "title": "Pour les relecteurs",
-      "noContent": "Aucune information pour les relecteurs/relectrices disponible pour cette revue."
+      "noContent": "Aucune information pour les relecteurs/relectrices disponible pour cette revue.",
+      "description": "Informations et ressources pour les relecteurs"
     },
     "forEditors": {
       "title": "Pour les rédacteurs/rédactrices",
-      "noContent": "Aucune information pour les rédacteurs/rédactrices disponible pour cette revue."
+      "noContent": "Aucune information pour les rédacteurs/rédactrices disponible pour cette revue.",
+      "description": "Informations et ressources pour les rédacteurs"
     },
     "forConferenceOrganisers": {
       "title": "Pour les organisateurs de conférences",
-      "noContent": "Aucune information pour les organisateurs de conférences disponible pour cette revue."
+      "noContent": "Aucune information pour les organisateurs de conférences disponible pour cette revue.",
+      "description": "Informations et ressources pour les organisateurs de conférences"
     },
     "proposingSpecialIssues": {
       "title": "Proposer des numéros spéciaux",
-      "noContent": "Aucune information sur la proposition de numéros spéciaux disponible pour cette revue."
+      "noContent": "Aucune information sur la proposition de numéros spéciaux disponible pour cette revue.",
+      "description": "Guide pour proposer des numéros spéciaux"
     },
     "accessibility": {
       "title": "Accessibilité",
@@ -530,7 +552,8 @@
       "noContent": "Contenu non trouvé."
     },
     "credits": {
-      "title": "Crédits"
+      "title": "Crédits",
+      "description": "Crédits et mentions légales"
     }
   }
 }

--- a/src/app/sites/[journalId]/[lang]/about/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/about/page.tsx
@@ -2,10 +2,10 @@ import { Metadata } from 'next';
 import dynamic from 'next/dynamic';
 import './About.scss';
 import { fetchAboutPage } from '@/services/about';
-import { IPage } from '@/types/page';
 import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getFilteredJournals } from '@/utils/journal-filter';
-import { acceptedLanguages, getLanguageFromParams } from '@/utils/language-utils';
+import { acceptedLanguages } from '@/utils/language-utils';
+import { generateSeoAlternates } from '@/utils/seo';
 
 const AboutClient = dynamic(() => import('./AboutClient'));
 
@@ -26,10 +26,17 @@ export async function generateStaticParams() {
   return params;
 }
 
-export const metadata: Metadata = {
-  title: 'À propos',
-  description: 'À propos de la revue',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  return {
+    title: 'À propos',
+    description: 'À propos de la revue',
+    alternates: generateSeoAlternates(journalId, lang, '/about'),
+  };
+}
 
 export default async function AboutPage(props: {
   params: Promise<{ journalId: string; lang: string }>;

--- a/src/app/sites/[journalId]/[lang]/about/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/about/page.tsx
@@ -31,9 +31,10 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
   return {
-    title: 'À propos',
-    description: 'À propos de la revue',
+    title: t('pages.about.title', translations),
+    description: t('pages.about.description', translations),
     alternates: generateSeoAlternates(journalId, lang, '/about'),
   };
 }

--- a/src/app/sites/[journalId]/[lang]/accessibility/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/accessibility/page.tsx
@@ -6,6 +6,7 @@ import { getBreadcrumbHierarchy } from '@/utils/breadcrumbs';
 import MarkdownPageWithSidebar from '@/components/MarkdownPageWithSidebar/MarkdownPageWithSidebar';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages, defaultLanguage } from '@/utils/language-utils';
+import { generateSeoAlternates } from '@/utils/seo';
 
 export const revalidate = false;
 
@@ -24,15 +25,16 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata(props: {
-  params: Promise<{ lang: string }>;
+  params: Promise<{ journalId: string; lang: string }>;
 }): Promise<Metadata> {
   const params = await props.params;
-  const { lang } = params;
+  const { journalId, lang } = params;
   const translations = await getServerTranslations(lang);
 
   return {
     title: translate('pages.accessibility.title', translations),
     description: translate('pages.accessibility.description', translations),
+    alternates: generateSeoAlternates(journalId, lang, '/accessibility'),
   };
 }
 

--- a/src/app/sites/[journalId]/[lang]/acknowledgements/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/acknowledgements/page.tsx
@@ -12,7 +12,7 @@ const AcknowledgementsClient = dynamic(() => import('./AcknowledgementsClient'))
 // Stable editorial content - no ISR, fully static at build time
 export const revalidate = false;
 
-// Pre-generate accessibility page for all journals at build time
+// Pre-generate acknowledgements page for all journals at build time
 export async function generateStaticParams() {
   const journals = getFilteredJournals();
   const params: { journalId: string; lang: string }[] = [];
@@ -31,8 +31,10 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
   return {
-    title: 'Acknowledgements',
+    title: t('pages.acknowledgements.title', translations),
+    description: t('pages.acknowledgements.description', translations),
     alternates: generateSeoAlternates(journalId, lang, '/acknowledgements'),
   };
 }

--- a/src/app/sites/[journalId]/[lang]/acknowledgements/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/acknowledgements/page.tsx
@@ -5,13 +5,14 @@ import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getBreadcrumbHierarchy } from '@/utils/breadcrumbs';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
+import { generateSeoAlternates } from '@/utils/seo';
 
 const AcknowledgementsClient = dynamic(() => import('./AcknowledgementsClient'));
 
 // Stable editorial content - no ISR, fully static at build time
 export const revalidate = false;
 
-// Pre-generate acknowledgements page for all journals at build time
+// Pre-generate accessibility page for all journals at build time
 export async function generateStaticParams() {
   const journals = getFilteredJournals();
   const params: { journalId: string; lang: string }[] = [];
@@ -25,10 +26,16 @@ export async function generateStaticParams() {
   return params;
 }
 
-export const metadata: Metadata = {
-  title: 'Acknowledgements',
-  description: 'Journal acknowledgements',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  return {
+    title: 'Acknowledgements',
+    alternates: generateSeoAlternates(journalId, lang, '/acknowledgements'),
+  };
+}
 
 export default async function AcknowledgementsPage(props: {
   params: Promise<{ journalId: string; lang: string }>;

--- a/src/app/sites/[journalId]/[lang]/articles-accepted/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/articles-accepted/page.tsx
@@ -2,17 +2,25 @@ import type { Metadata } from 'next';
 
 import { fetchArticles } from '@/services/article';
 import { getServerTranslations, t } from '@/utils/server-i18n';
+import { generateSeoAlternates } from '@/utils/seo';
 
 import dynamic from 'next/dynamic';
 import { connection } from 'next/server';
 
 const ArticlesAcceptedClient = dynamic(() => import('./ArticlesAcceptedClient'));
 
-// Métadonnées pour la page
-export const metadata: Metadata = {
-  title: 'Articles acceptés',
-  description: 'Articles acceptés',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
+  return {
+    title: t('pages.articlesAccepted.title', translations),
+    description: t('pages.articlesAccepted.description', translations),
+    alternates: generateSeoAlternates(journalId, lang, '/articles-accepted'),
+  };
+}
 
 export default async function ArticlesAcceptedPage(props: {
   params: Promise<{ lang: string; journalId: string }>;
@@ -24,7 +32,6 @@ export default async function ArticlesAcceptedPage(props: {
   try {
     const ARTICLES_ACCEPTED_PER_PAGE = 10;
 
-    // Récupération dynamique des articles acceptés
     if (!journalId) {
       throw new Error('journalId is not defined');
     }
@@ -40,12 +47,10 @@ export default async function ArticlesAcceptedPage(props: {
       getServerTranslations(lang),
     ]);
 
-    // S'assurer que les données sont correctement formatées pour le client
     const formattedArticles = {
       data: Array.isArray(articlesAccepted.data) ? articlesAccepted.data : [],
       totalItems: articlesAccepted.totalItems || 0,
       range: {
-        // Vérification explicite de l'existence des types dans range
         types:
           articlesAccepted.range && 'types' in articlesAccepted.range
             ? Array.isArray(articlesAccepted.range.types)
@@ -75,7 +80,6 @@ export default async function ArticlesAcceptedPage(props: {
     );
   } catch (error) {
     console.error('Error fetching articles accepted:', error);
-    // Retourner un état vide en cas d'erreur
     return (
       <ArticlesAcceptedClient
         initialArticles={{ data: [], totalItems: 0 }}

--- a/src/app/sites/[journalId]/[lang]/articles/[id]/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/articles/[id]/page.tsx
@@ -15,6 +15,8 @@ import { initBuildProgress, logArticleProgress } from '@/utils/build-progress';
 import { generateArticleMetadata } from '@/components/Meta/ArticleMeta/ArticleMeta';
 import { AvailableLanguage } from '@/utils/i18n';
 import { loadJournalConfig } from '@/utils/env-loader';
+import { getJournalBaseUrl } from '@/utils/signposting';
+import { acceptedLanguages } from '@/utils/language-utils';
 
 interface ArticleDetailsPageProps {
   params: Promise<{
@@ -87,6 +89,15 @@ export async function generateMetadata(props: ArticleDetailsPageProps): Promise<
       );
     }
 
+    // SEO: Calculate canonical URL and alternates
+    const baseUrl = getJournalBaseUrl(journalId);
+    const canonicalUrl = `${baseUrl}/${language}/articles/${id}`;
+
+    const alternateLanguages: Record<string, string> = {};
+    acceptedLanguages.forEach(lang => {
+      alternateLanguages[lang] = `${baseUrl}/${lang}/articles/${id}`;
+    });
+
     return generateArticleMetadata({
       language,
       article,
@@ -95,6 +106,8 @@ export async function generateMetadata(props: ArticleDetailsPageProps): Promise<
       authors,
       coarInboxUrl,
       relatedVolume,
+      canonicalUrl,
+      alternateLanguages,
     });
   } catch (error) {
     console.error(

--- a/src/app/sites/[journalId]/[lang]/articles/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/articles/page.tsx
@@ -32,9 +32,10 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
   return {
-    title: 'Articles',
-    description: 'Articles',
+    title: t('pages.articles.title', translations),
+    description: t('pages.articles.description', translations),
     alternates: generateSeoAlternates(journalId, lang, '/articles'),
   };
 }
@@ -68,7 +69,6 @@ export default async function ArticlesPage(props: {
       throw new Error('Journal code not available');
     }
 
-    // Récupération dynamique des articles (en parallèle avec les traductions)
     const [translations, articles] = await Promise.all([
       translationsPromise,
       fetchArticles({
@@ -80,7 +80,6 @@ export default async function ArticlesPage(props: {
       }),
     ]);
 
-    // S'assurer que les données sont dans le bon format
     const formattedArticles: ArticlesData = {
       data: Array.isArray(articles.data) ? articles.data : [],
       totalItems: articles.totalItems || 0,

--- a/src/app/sites/[journalId]/[lang]/articles/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/articles/page.tsx
@@ -1,13 +1,12 @@
 import type { Metadata } from 'next';
-
 import { fetchArticles } from '@/services/article';
 import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
-
 import dynamic from 'next/dynamic';
 import { Suspense } from 'react';
 import Loader from '@/components/Loader/Loader';
+import { generateSeoAlternates } from '@/utils/seo';
 
 const ArticlesClient = dynamic(() => import('./ArticlesClient'));
 
@@ -28,10 +27,17 @@ export async function generateStaticParams() {
   return params;
 }
 
-export const metadata: Metadata = {
-  title: 'Articles',
-  description: 'Articles',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  return {
+    title: 'Articles',
+    description: 'Articles',
+    alternates: generateSeoAlternates(journalId, lang, '/articles'),
+  };
+}
 
 interface ArticlesData {
   data: any[];

--- a/src/app/sites/[journalId]/[lang]/authors/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/authors/page.tsx
@@ -1,17 +1,24 @@
 import { Metadata } from 'next';
 import dynamic from 'next/dynamic';
 import { getServerTranslations, t } from '@/utils/server-i18n';
+import { generateSeoAlternates } from '@/utils/seo';
 import { connection } from 'next/server';
 import './Authors.scss';
 
-const AuthorsClient = dynamic(() => import('./AuthorsClient'), {
-  loading: () => <div className="loader">Chargement...</div>,
-});
+const AuthorsClient = dynamic(() => import('./AuthorsClient'));
 
-export const metadata: Metadata = {
-  title: 'Auteurs',
-  description: 'Liste des auteurs',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
+  return {
+    title: t('pages.authors.title', translations),
+    description: t('pages.authors.description', translations),
+    alternates: generateSeoAlternates(journalId, lang, '/authors'),
+  };
+}
 
 interface AuthorsPageProps {
   params: Promise<{ lang: string; journalId: string }>;

--- a/src/app/sites/[journalId]/[lang]/boards/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/boards/page.tsx
@@ -4,6 +4,7 @@ import { fetchBoardMembers, fetchBoardPages } from '@/services/board';
 import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
+import { generateSeoAlternates } from '@/utils/seo';
 
 import dynamic from 'next/dynamic';
 
@@ -26,9 +27,16 @@ export async function generateStaticParams() {
   return params;
 }
 
-export const metadata: Metadata = {
-  title: 'Boards',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  return {
+    title: 'Comités',
+    alternates: generateSeoAlternates(journalId, lang, '/boards'),
+  };
+}
 
 export default async function BoardsPage(props: {
   params: Promise<{ journalId: string; lang: string }>;

--- a/src/app/sites/[journalId]/[lang]/boards/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/boards/page.tsx
@@ -32,8 +32,10 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
   return {
-    title: 'Comités',
+    title: t('pages.boards.title', translations),
+    description: t('pages.boards.description', translations),
     alternates: generateSeoAlternates(journalId, lang, '/boards'),
   };
 }

--- a/src/app/sites/[journalId]/[lang]/credits/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/credits/page.tsx
@@ -5,13 +5,14 @@ import { fetchCreditsPage } from '@/services/credits';
 import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
+import { generateSeoAlternates } from '@/utils/seo';
 
 const CreditsClient = dynamic(() => import('./CreditsClient'));
 
 // Stable editorial content - no ISR, fully static at build time
 export const revalidate = false;
 
-// Pre-generate credits page for all journals at build time
+// Pre-generate accessibility page for all journals at build time
 export async function generateStaticParams() {
   const journals = getFilteredJournals();
   const params: { journalId: string; lang: string }[] = [];
@@ -25,10 +26,16 @@ export async function generateStaticParams() {
   return params;
 }
 
-export const metadata: Metadata = {
-  title: 'Crédits',
-  description: 'Crédits et mentions légales',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  return {
+    title: 'Crédits',
+    alternates: generateSeoAlternates(journalId, lang, '/credits'),
+  };
+}
 
 export default async function CreditsPage(props: {
   params: Promise<{ journalId: string; lang: string }>;

--- a/src/app/sites/[journalId]/[lang]/credits/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/credits/page.tsx
@@ -12,7 +12,7 @@ const CreditsClient = dynamic(() => import('./CreditsClient'));
 // Stable editorial content - no ISR, fully static at build time
 export const revalidate = false;
 
-// Pre-generate accessibility page for all journals at build time
+// Pre-generate credits page for all journals at build time
 export async function generateStaticParams() {
   const journals = getFilteredJournals();
   const params: { journalId: string; lang: string }[] = [];
@@ -31,8 +31,10 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
   return {
-    title: 'Crédits',
+    title: t('pages.credits.title', translations),
+    description: t('pages.credits.description', translations),
     alternates: generateSeoAlternates(journalId, lang, '/credits'),
   };
 }

--- a/src/app/sites/[journalId]/[lang]/ethical-charter/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/ethical-charter/page.tsx
@@ -12,7 +12,7 @@ const EthicalCharterClient = dynamic(() => import('./EthicalCharterClient'));
 // Stable editorial content - no ISR, fully static at build time
 export const revalidate = false;
 
-// Pre-generate accessibility page for all journals at build time
+// Pre-generate ethical-charter page for all journals at build time
 export async function generateStaticParams() {
   const journals = getFilteredJournals();
   const params: { journalId: string; lang: string }[] = [];
@@ -31,8 +31,10 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
   return {
-    title: 'Charte éthique',
+    title: t('pages.ethicalCharter.title', translations),
+    description: t('pages.ethicalCharter.description', translations),
     alternates: generateSeoAlternates(journalId, lang, '/ethical-charter'),
   };
 }

--- a/src/app/sites/[journalId]/[lang]/ethical-charter/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/ethical-charter/page.tsx
@@ -5,13 +5,14 @@ import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getBreadcrumbHierarchy } from '@/utils/breadcrumbs';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
+import { generateSeoAlternates } from '@/utils/seo';
 
 const EthicalCharterClient = dynamic(() => import('./EthicalCharterClient'));
 
 // Stable editorial content - no ISR, fully static at build time
 export const revalidate = false;
 
-// Pre-generate ethical charter page for all journals at build time
+// Pre-generate accessibility page for all journals at build time
 export async function generateStaticParams() {
   const journals = getFilteredJournals();
   const params: { journalId: string; lang: string }[] = [];
@@ -25,34 +26,36 @@ export async function generateStaticParams() {
   return params;
 }
 
-export const metadata: Metadata = {
-  title: 'Ethical Charter',
-  description: 'Journal ethical charter',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  return {
+    title: 'Charte éthique',
+    alternates: generateSeoAlternates(journalId, lang, '/ethical-charter'),
+  };
+}
 
 export default async function EthicalCharterPage(props: {
   params: Promise<{ journalId: string; lang: string }>;
 }) {
   const params = await props.params;
-  let pageData = null;
   const { journalId, lang } = params;
 
-  const translationsPromise = getServerTranslations(lang);
+  let pageData = null;
+  let translations = {};
 
   try {
-    if (journalId) {
-      pageData = await fetchEthicalCharterPage(journalId);
-      if (!pageData) {
-        console.warn(
-          `[Build] Ethical Charter page content not found for journal "${journalId}" on API.`
-        );
-      }
-    }
+    // Fetch all pages and translations in parallel
+    [pageData, translations] = await Promise.all([
+      journalId ? fetchEthicalCharterPage(journalId) : null,
+      getServerTranslations(lang),
+    ]);
   } catch (error) {
-    console.warn(`[Build] Could not reach API for Ethical Charter page of journal "${journalId}".`);
+    console.warn('[EthicalCharterPage] Failed to fetch data:', error);
   }
 
-  const translations = await translationsPromise;
   const breadcrumbLabels = {
     parents: getBreadcrumbHierarchy('/ethical-charter', translations),
     current: t('pages.ethicalCharter.title', translations),

--- a/src/app/sites/[journalId]/[lang]/for-authors/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/for-authors/page.tsx
@@ -10,6 +10,8 @@ import { getBreadcrumbHierarchy } from '@/utils/breadcrumbs';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
 
+import { generateSeoAlternates } from '@/utils/seo';
+
 const ForAuthorsClient = dynamic(() => import('./ForAuthorsClient'));
 
 // Stable editorial content - no ISR, fully static at build time
@@ -30,9 +32,14 @@ export async function generateStaticParams() {
 }
 
 // Cette fonction est aussi appelée au build time
-export async function generateMetadata(): Promise<Metadata> {
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
   return {
     title: 'For Authors',
+    alternates: generateSeoAlternates(journalId, lang, '/for-authors'),
   };
 }
 

--- a/src/app/sites/[journalId]/[lang]/for-authors/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/for-authors/page.tsx
@@ -31,14 +31,15 @@ export async function generateStaticParams() {
   return params;
 }
 
-// Cette fonction est aussi appelée au build time
 export async function generateMetadata(props: {
   params: Promise<{ journalId: string; lang: string }>;
 }): Promise<Metadata> {
   const params = await props.params;
   const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
   return {
-    title: 'For Authors',
+    title: t('pages.forAuthors.title', translations),
+    description: t('pages.forAuthors.description', translations),
     alternates: generateSeoAlternates(journalId, lang, '/for-authors'),
   };
 }

--- a/src/app/sites/[journalId]/[lang]/for-conference-organisers/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/for-conference-organisers/page.tsx
@@ -1,19 +1,18 @@
 import { Metadata } from 'next';
 import dynamic from 'next/dynamic';
-import { notFound } from 'next/navigation';
 import { fetchForConferenceOrganisersPage } from '@/services/forConferenceOrganisers';
 import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getBreadcrumbHierarchy } from '@/utils/breadcrumbs';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
-import { getPublicJournalConfig } from '@/utils/env-loader';
+import { generateSeoAlternates } from '@/utils/seo';
 
 const ForConferenceOrganisersClient = dynamic(() => import('./ForConferenceOrganisersClient'));
 
 // Stable editorial content - no ISR, fully static at build time
 export const revalidate = false;
 
-// Pre-generate for-conference-organisers page for all journals at build time
+// Pre-generate accessibility page for all journals at build time
 export async function generateStaticParams() {
   const journals = getFilteredJournals();
   const params: { journalId: string; lang: string }[] = [];
@@ -27,44 +26,36 @@ export async function generateStaticParams() {
   return params;
 }
 
-export const metadata: Metadata = {
-  title: 'For Conference Organisers',
-  description: 'Information for conference organisers',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  return {
+    title: 'For conference organisers',
+    alternates: generateSeoAlternates(journalId, lang, '/for-conference-organisers'),
+  };
+}
 
 export default async function ForConferenceOrganisersPage(props: {
   params: Promise<{ journalId: string; lang: string }>;
 }) {
   const params = await props.params;
-  let pageData = null;
   const { journalId, lang } = params;
 
-  // Check if this page should be rendered for this journal
-  const journalConfig = getPublicJournalConfig(journalId);
-  if (journalConfig.NEXT_PUBLIC_JOURNAL_MENU_JOURNAL_FOR_CONFERENCE_ORGANISERS_RENDER === 'false') {
-    notFound();
-  }
-
-  const translationsPromise = getServerTranslations(lang);
+  let pageData = null;
+  let translations = {};
 
   try {
-    if (journalId) {
-      const rawData = await fetchForConferenceOrganisersPage(journalId);
-      if (rawData?.['hydra:member']?.[0]) {
-        pageData = rawData['hydra:member'][0];
-      } else {
-        console.warn(
-          `[Build] For Conference Organisers page content not found for journal "${journalId}" on API.`
-        );
-      }
-    }
+    // Fetch all pages and translations in parallel
+    [pageData, translations] = await Promise.all([
+      journalId ? fetchForConferenceOrganisersPage(journalId) : null,
+      getServerTranslations(lang),
+    ]);
   } catch (error) {
-    console.warn(
-      `[Build] Could not reach API for For Conference Organisers page of journal "${journalId}".`
-    );
+    console.warn('[ForConferenceOrganisersPage] Failed to fetch data:', error);
   }
 
-  const translations = await translationsPromise;
   const breadcrumbLabels = {
     parents: getBreadcrumbHierarchy('/for-conference-organisers', translations),
     current: t('pages.forConferenceOrganisers.title', translations),

--- a/src/app/sites/[journalId]/[lang]/for-conference-organisers/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/for-conference-organisers/page.tsx
@@ -1,10 +1,12 @@
 import { Metadata } from 'next';
 import dynamic from 'next/dynamic';
+import { notFound } from 'next/navigation';
 import { fetchForConferenceOrganisersPage } from '@/services/forConferenceOrganisers';
 import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getBreadcrumbHierarchy } from '@/utils/breadcrumbs';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
+import { getPublicJournalConfig } from '@/utils/env-loader';
 import { generateSeoAlternates } from '@/utils/seo';
 
 const ForConferenceOrganisersClient = dynamic(() => import('./ForConferenceOrganisersClient'));
@@ -12,7 +14,7 @@ const ForConferenceOrganisersClient = dynamic(() => import('./ForConferenceOrgan
 // Stable editorial content - no ISR, fully static at build time
 export const revalidate = false;
 
-// Pre-generate accessibility page for all journals at build time
+// Pre-generate for-conference-organisers page for all journals at build time
 export async function generateStaticParams() {
   const journals = getFilteredJournals();
   const params: { journalId: string; lang: string }[] = [];
@@ -31,8 +33,10 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
   return {
-    title: 'For conference organisers',
+    title: t('pages.forConferenceOrganisers.title', translations),
+    description: t('pages.forConferenceOrganisers.description', translations),
     alternates: generateSeoAlternates(journalId, lang, '/for-conference-organisers'),
   };
 }
@@ -43,15 +47,21 @@ export default async function ForConferenceOrganisersPage(props: {
   const params = await props.params;
   const { journalId, lang } = params;
 
+  const journalConfig = getPublicJournalConfig(journalId);
+  if (journalConfig.NEXT_PUBLIC_JOURNAL_MENU_JOURNAL_FOR_CONFERENCE_ORGANISERS_RENDER === 'false') {
+    notFound();
+  }
+
   let pageData = null;
   let translations = {};
 
   try {
-    // Fetch all pages and translations in parallel
-    [pageData, translations] = await Promise.all([
-      journalId ? fetchForConferenceOrganisersPage(journalId) : null,
+    let rawData = null;
+    [rawData, translations] = await Promise.all([
+      fetchForConferenceOrganisersPage(journalId),
       getServerTranslations(lang),
     ]);
+    pageData = rawData?.['hydra:member']?.[0] ?? null;
   } catch (error) {
     console.warn('[ForConferenceOrganisersPage] Failed to fetch data:', error);
   }

--- a/src/app/sites/[journalId]/[lang]/for-editors/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/for-editors/page.tsx
@@ -1,19 +1,18 @@
 import { Metadata } from 'next';
 import dynamic from 'next/dynamic';
-import { notFound } from 'next/navigation';
 import { fetchForEditorsPage } from '@/services/forEditors';
 import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getBreadcrumbHierarchy } from '@/utils/breadcrumbs';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
-import { getPublicJournalConfig } from '@/utils/env-loader';
+import { generateSeoAlternates } from '@/utils/seo';
 
 const ForEditorsClient = dynamic(() => import('./ForEditorsClient'));
 
 // Stable editorial content - no ISR, fully static at build time
 export const revalidate = false;
 
-// Pre-generate for-editors page for all journals at build time
+// Pre-generate accessibility page for all journals at build time
 export async function generateStaticParams() {
   const journals = getFilteredJournals();
   const params: { journalId: string; lang: string }[] = [];
@@ -27,42 +26,36 @@ export async function generateStaticParams() {
   return params;
 }
 
-export const metadata: Metadata = {
-  title: 'For Editors',
-  description: 'Information for journal editors',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  return {
+    title: 'For editors',
+    alternates: generateSeoAlternates(journalId, lang, '/for-editors'),
+  };
+}
 
 export default async function ForEditorsPage(props: {
   params: Promise<{ journalId: string; lang: string }>;
 }) {
   const params = await props.params;
-  let pageData = null;
   const { journalId, lang } = params;
 
-  // Hidden by default — requires explicit opt-in via env var
-  const journalConfig = getPublicJournalConfig(journalId);
-  if (journalConfig.NEXT_PUBLIC_JOURNAL_MENU_JOURNAL_FOR_EDITORS_RENDER !== 'true') {
-    notFound();
-  }
-
-  const translationsPromise = getServerTranslations(lang);
+  let pageData = null;
+  let translations = {};
 
   try {
-    if (journalId) {
-      const rawData = await fetchForEditorsPage(journalId);
-      if (rawData?.['hydra:member']?.[0]) {
-        pageData = rawData['hydra:member'][0];
-      } else {
-        console.warn(
-          `[Build] For Editors page content not found for journal "${journalId}" on API.`
-        );
-      }
-    }
+    // Fetch all pages and translations in parallel
+    [pageData, translations] = await Promise.all([
+      journalId ? fetchForEditorsPage(journalId) : null,
+      getServerTranslations(lang),
+    ]);
   } catch (error) {
-    console.warn(`[Build] Could not reach API for For Editors page of journal "${journalId}".`);
+    console.warn('[ForEditorsPage] Failed to fetch data:', error);
   }
 
-  const translations = await translationsPromise;
   const breadcrumbLabels = {
     parents: getBreadcrumbHierarchy('/for-editors', translations),
     current: t('pages.forEditors.title', translations),

--- a/src/app/sites/[journalId]/[lang]/for-editors/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/for-editors/page.tsx
@@ -1,10 +1,12 @@
 import { Metadata } from 'next';
 import dynamic from 'next/dynamic';
+import { notFound } from 'next/navigation';
 import { fetchForEditorsPage } from '@/services/forEditors';
 import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getBreadcrumbHierarchy } from '@/utils/breadcrumbs';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
+import { getPublicJournalConfig } from '@/utils/env-loader';
 import { generateSeoAlternates } from '@/utils/seo';
 
 const ForEditorsClient = dynamic(() => import('./ForEditorsClient'));
@@ -12,7 +14,7 @@ const ForEditorsClient = dynamic(() => import('./ForEditorsClient'));
 // Stable editorial content - no ISR, fully static at build time
 export const revalidate = false;
 
-// Pre-generate accessibility page for all journals at build time
+// Pre-generate for-editors page for all journals at build time
 export async function generateStaticParams() {
   const journals = getFilteredJournals();
   const params: { journalId: string; lang: string }[] = [];
@@ -31,8 +33,10 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
   return {
-    title: 'For editors',
+    title: t('pages.forEditors.title', translations),
+    description: t('pages.forEditors.description', translations),
     alternates: generateSeoAlternates(journalId, lang, '/for-editors'),
   };
 }
@@ -43,15 +47,21 @@ export default async function ForEditorsPage(props: {
   const params = await props.params;
   const { journalId, lang } = params;
 
+  const journalConfig = getPublicJournalConfig(journalId);
+  if (journalConfig.NEXT_PUBLIC_JOURNAL_MENU_JOURNAL_FOR_EDITORS_RENDER !== 'true') {
+    notFound();
+  }
+
   let pageData = null;
   let translations = {};
 
   try {
-    // Fetch all pages and translations in parallel
-    [pageData, translations] = await Promise.all([
-      journalId ? fetchForEditorsPage(journalId) : null,
+    let rawData = null;
+    [rawData, translations] = await Promise.all([
+      fetchForEditorsPage(journalId),
       getServerTranslations(lang),
     ]);
+    pageData = rawData?.['hydra:member']?.[0] ?? null;
   } catch (error) {
     console.warn('[ForEditorsPage] Failed to fetch data:', error);
   }

--- a/src/app/sites/[journalId]/[lang]/for-reviewers/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/for-reviewers/page.tsx
@@ -1,10 +1,12 @@
 import { Metadata } from 'next';
 import dynamic from 'next/dynamic';
+import { notFound } from 'next/navigation';
 import { fetchForReviewersPage } from '@/services/forReviewers';
 import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getBreadcrumbHierarchy } from '@/utils/breadcrumbs';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
+import { getPublicJournalConfig } from '@/utils/env-loader';
 import { generateSeoAlternates } from '@/utils/seo';
 
 const ForReviewersClient = dynamic(() => import('./ForReviewersClient'));
@@ -12,7 +14,7 @@ const ForReviewersClient = dynamic(() => import('./ForReviewersClient'));
 // Stable editorial content - no ISR, fully static at build time
 export const revalidate = false;
 
-// Pre-generate accessibility page for all journals at build time
+// Pre-generate for-reviewers page for all journals at build time
 export async function generateStaticParams() {
   const journals = getFilteredJournals();
   const params: { journalId: string; lang: string }[] = [];
@@ -31,8 +33,10 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
   return {
-    title: 'For reviewers',
+    title: t('pages.forReviewers.title', translations),
+    description: t('pages.forReviewers.description', translations),
     alternates: generateSeoAlternates(journalId, lang, '/for-reviewers'),
   };
 }
@@ -43,15 +47,21 @@ export default async function ForReviewersPage(props: {
   const params = await props.params;
   const { journalId, lang } = params;
 
+  const journalConfig = getPublicJournalConfig(journalId);
+  if (journalConfig.NEXT_PUBLIC_JOURNAL_MENU_JOURNAL_FOR_REVIEWERS_RENDER === 'false') {
+    notFound();
+  }
+
   let pageData = null;
   let translations = {};
 
   try {
-    // Fetch all pages and translations in parallel
-    [pageData, translations] = await Promise.all([
-      journalId ? fetchForReviewersPage(journalId) : null,
+    let rawData = null;
+    [rawData, translations] = await Promise.all([
+      fetchForReviewersPage(journalId),
       getServerTranslations(lang),
     ]);
+    pageData = rawData?.['hydra:member']?.[0] ?? null;
   } catch (error) {
     console.warn('[ForReviewersPage] Failed to fetch data:', error);
   }

--- a/src/app/sites/[journalId]/[lang]/for-reviewers/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/for-reviewers/page.tsx
@@ -1,19 +1,18 @@
 import { Metadata } from 'next';
 import dynamic from 'next/dynamic';
-import { notFound } from 'next/navigation';
 import { fetchForReviewersPage } from '@/services/forReviewers';
 import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getBreadcrumbHierarchy } from '@/utils/breadcrumbs';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
-import { getPublicJournalConfig } from '@/utils/env-loader';
+import { generateSeoAlternates } from '@/utils/seo';
 
 const ForReviewersClient = dynamic(() => import('./ForReviewersClient'));
 
 // Stable editorial content - no ISR, fully static at build time
 export const revalidate = false;
 
-// Pre-generate for-reviewers page for all journals at build time
+// Pre-generate accessibility page for all journals at build time
 export async function generateStaticParams() {
   const journals = getFilteredJournals();
   const params: { journalId: string; lang: string }[] = [];
@@ -27,42 +26,36 @@ export async function generateStaticParams() {
   return params;
 }
 
-export const metadata: Metadata = {
-  title: 'For Reviewers',
-  description: 'Information for journal reviewers',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  return {
+    title: 'For reviewers',
+    alternates: generateSeoAlternates(journalId, lang, '/for-reviewers'),
+  };
+}
 
 export default async function ForReviewersPage(props: {
   params: Promise<{ journalId: string; lang: string }>;
 }) {
   const params = await props.params;
-  let pageData = null;
   const { journalId, lang } = params;
 
-  // Check if this page should be rendered for this journal
-  const journalConfig = getPublicJournalConfig(journalId);
-  if (journalConfig.NEXT_PUBLIC_JOURNAL_MENU_JOURNAL_FOR_REVIEWERS_RENDER === 'false') {
-    notFound();
-  }
-
-  const translationsPromise = getServerTranslations(lang);
+  let pageData = null;
+  let translations = {};
 
   try {
-    if (journalId) {
-      const rawData = await fetchForReviewersPage(journalId);
-      if (rawData?.['hydra:member']?.[0]) {
-        pageData = rawData['hydra:member'][0];
-      } else {
-        console.warn(
-          `[Build] For Reviewers page content not found for journal "${journalId}" on API.`
-        );
-      }
-    }
+    // Fetch all pages and translations in parallel
+    [pageData, translations] = await Promise.all([
+      journalId ? fetchForReviewersPage(journalId) : null,
+      getServerTranslations(lang),
+    ]);
   } catch (error) {
-    console.warn(`[Build] Could not reach API for For Reviewers page of journal "${journalId}".`);
+    console.warn('[ForReviewersPage] Failed to fetch data:', error);
   }
 
-  const translations = await translationsPromise;
   const breadcrumbLabels = {
     parents: getBreadcrumbHierarchy('/for-reviewers', translations),
     current: t('pages.forReviewers.title', translations),

--- a/src/app/sites/[journalId]/[lang]/indexing/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/indexing/page.tsx
@@ -12,7 +12,7 @@ const IndexingClient = dynamic(() => import('./IndexingClient'));
 // Stable editorial content - no ISR, fully static at build time
 export const revalidate = false;
 
-// Pre-generate accessibility page for all journals at build time
+// Pre-generate indexing page for all journals at build time
 export async function generateStaticParams() {
   const journals = getFilteredJournals();
   const params: { journalId: string; lang: string }[] = [];
@@ -31,8 +31,10 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
   return {
-    title: 'Indexation',
+    title: t('pages.indexing.title', translations),
+    description: t('pages.indexing.description', translations),
     alternates: generateSeoAlternates(journalId, lang, '/indexing'),
   };
 }

--- a/src/app/sites/[journalId]/[lang]/indexing/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/indexing/page.tsx
@@ -5,14 +5,14 @@ import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getBreadcrumbHierarchy } from '@/utils/breadcrumbs';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
-import './Indexing.scss';
+import { generateSeoAlternates } from '@/utils/seo';
 
 const IndexingClient = dynamic(() => import('./IndexingClient'));
 
 // Stable editorial content - no ISR, fully static at build time
 export const revalidate = false;
 
-// Pre-generate indexing page for all journals at build time
+// Pre-generate accessibility page for all journals at build time
 export async function generateStaticParams() {
   const journals = getFilteredJournals();
   const params: { journalId: string; lang: string }[] = [];
@@ -26,40 +26,42 @@ export async function generateStaticParams() {
   return params;
 }
 
-export const metadata: Metadata = {
-  title: 'Indexing',
-  description: 'Journal indexing information',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  return {
+    title: 'Indexation',
+    alternates: generateSeoAlternates(journalId, lang, '/indexing'),
+  };
+}
 
 export default async function IndexingPage(props: {
   params: Promise<{ journalId: string; lang: string }>;
 }) {
   const params = await props.params;
-  let pageData = null;
   const { journalId, lang } = params;
 
-  const translationsPromise = getServerTranslations(lang);
+  let pageData = null;
+  let translations = {};
 
   try {
-    if (journalId) {
-      const rawData = await fetchIndexingPage(journalId);
-      if (rawData?.['hydra:member']?.[0]) {
-        pageData = rawData['hydra:member'][0];
-      } else {
-        console.warn(
-          `[Build] Indexing page content not found for journal "${journalId}" on API. It will be empty.`
-        );
-      }
-    }
+    // Fetch all pages and translations in parallel
+    [pageData, translations] = await Promise.all([
+      journalId ? fetchIndexingPage(journalId) : null,
+      getServerTranslations(lang),
+    ]);
   } catch (error) {
-    console.warn(`[Build] Could not reach API for Indexing page of journal "${journalId}".`);
+    console.warn('[IndexingPage] Failed to fetch data:', error);
   }
 
-  const translations = await translationsPromise;
   const breadcrumbLabels = {
     parents: getBreadcrumbHierarchy('/indexing', translations),
     current: t('pages.indexing.title', translations),
   };
 
-  return <IndexingClient initialPage={pageData} lang={lang} breadcrumbLabels={breadcrumbLabels} />;
+  return (
+    <IndexingClient initialPage={pageData} lang={lang} breadcrumbLabels={breadcrumbLabels} />
+  );
 }

--- a/src/app/sites/[journalId]/[lang]/news/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/news/page.tsx
@@ -4,6 +4,7 @@ import { fetchNews } from '@/services/news';
 import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
+import { generateSeoAlternates } from '@/utils/seo';
 import './News.scss';
 
 const NewsClient = dynamic(() => import('./NewsClient'));
@@ -25,10 +26,17 @@ export async function generateStaticParams() {
   return params;
 }
 
-export const metadata: Metadata = {
-  title: 'Actualités',
-  description: 'Dernières actualités de la revue',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  return {
+    title: 'Actualités',
+    description: 'Dernières actualités de la revue',
+    alternates: generateSeoAlternates(journalId, lang, '/news'),
+  };
+}
 
 type Props = {
   params: Promise<{ journalId: string; lang: string }>;

--- a/src/app/sites/[journalId]/[lang]/news/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/news/page.tsx
@@ -31,9 +31,10 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
   return {
-    title: 'Actualités',
-    description: 'Dernières actualités de la revue',
+    title: t('pages.news.title', translations),
+    description: t('pages.news.description', translations),
     alternates: generateSeoAlternates(journalId, lang, '/news'),
   };
 }

--- a/src/app/sites/[journalId]/[lang]/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/page.tsx
@@ -1,13 +1,10 @@
 import { Metadata } from 'next';
-
 import { fetchHomeData } from '@/services/home';
-
 import { getFormattedSiteTitle } from '@/utils/metadata';
 import { acceptedLanguages } from '@/utils/language-utils';
 import { getFilteredJournals } from '@/utils/journal-filter';
-
 import dynamicImport from 'next/dynamic';
-
+import { generateSeoAlternates } from '@/utils/seo';
 import '@/styles/pages/Home.scss';
 
 const HomeClient = dynamicImport(() => import('@/components/HomeClient/HomeClient'));
@@ -29,10 +26,17 @@ export async function generateStaticParams() {
   return params;
 }
 
-export const metadata: Metadata = {
-  title: getFormattedSiteTitle('Accueil'),
-  description: "Page d'accueil de la revue",
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  return {
+    title: getFormattedSiteTitle('Accueil'),
+    description: "Page d'accueil de la revue",
+    alternates: generateSeoAlternates(journalId, lang, '/'),
+  };
+}
 
 // Fonction pour obtenir la langue par défaut
 function getDefaultLanguage(): string {

--- a/src/app/sites/[journalId]/[lang]/proposing-special-issues/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/proposing-special-issues/page.tsx
@@ -1,19 +1,18 @@
 import { Metadata } from 'next';
 import dynamic from 'next/dynamic';
-import { notFound } from 'next/navigation';
 import { fetchProposingSpecialIssuesPage } from '@/services/proposingSpecialIssues';
 import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getBreadcrumbHierarchy } from '@/utils/breadcrumbs';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
-import { getPublicJournalConfig } from '@/utils/env-loader';
+import { generateSeoAlternates } from '@/utils/seo';
 
 const ProposingSpecialIssuesClient = dynamic(() => import('./ProposingSpecialIssuesClient'));
 
 // Stable editorial content - no ISR, fully static at build time
 export const revalidate = false;
 
-// Pre-generate proposing-special-issues page for all journals at build time
+// Pre-generate accessibility page for all journals at build time
 export async function generateStaticParams() {
   const journals = getFilteredJournals();
   const params: { journalId: string; lang: string }[] = [];
@@ -27,44 +26,36 @@ export async function generateStaticParams() {
   return params;
 }
 
-export const metadata: Metadata = {
-  title: 'Proposing Special Issues',
-  description: 'Information about proposing special issues',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  return {
+    title: 'Proposing special issues',
+    alternates: generateSeoAlternates(journalId, lang, '/proposing-special-issues'),
+  };
+}
 
 export default async function ProposingSpecialIssuesPage(props: {
   params: Promise<{ journalId: string; lang: string }>;
 }) {
   const params = await props.params;
-  let pageData = null;
   const { journalId, lang } = params;
 
-  // Check if this page should be rendered for this journal
-  const journalConfig = getPublicJournalConfig(journalId);
-  if (journalConfig.NEXT_PUBLIC_JOURNAL_MENU_JOURNAL_PROPOSING_SPECIAL_ISSUES_RENDER !== 'true') {
-    notFound();
-  }
-
-  const translationsPromise = getServerTranslations(lang);
+  let pageData = null;
+  let translations = {};
 
   try {
-    if (journalId) {
-      const rawData = await fetchProposingSpecialIssuesPage(journalId);
-      if (rawData?.['hydra:member']?.[0]) {
-        pageData = rawData['hydra:member'][0];
-      } else {
-        console.warn(
-          `[Build] Proposing Special Issues page content not found for journal "${journalId}" on API.`
-        );
-      }
-    }
+    // Fetch all pages and translations in parallel
+    [pageData, translations] = await Promise.all([
+      journalId ? fetchProposingSpecialIssuesPage(journalId) : null,
+      getServerTranslations(lang),
+    ]);
   } catch (error) {
-    console.warn(
-      `[Build] Could not reach API for Proposing Special Issues page of journal "${journalId}".`
-    );
+    console.warn('[ProposingSpecialIssuesPage] Failed to fetch data:', error);
   }
 
-  const translations = await translationsPromise;
   const breadcrumbLabels = {
     parents: getBreadcrumbHierarchy('/proposing-special-issues', translations),
     current: t('pages.proposingSpecialIssues.title', translations),

--- a/src/app/sites/[journalId]/[lang]/proposing-special-issues/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/proposing-special-issues/page.tsx
@@ -12,7 +12,7 @@ const ProposingSpecialIssuesClient = dynamic(() => import('./ProposingSpecialIss
 // Stable editorial content - no ISR, fully static at build time
 export const revalidate = false;
 
-// Pre-generate accessibility page for all journals at build time
+// Pre-generate proposing-special-issues page for all journals at build time
 export async function generateStaticParams() {
   const journals = getFilteredJournals();
   const params: { journalId: string; lang: string }[] = [];
@@ -31,8 +31,10 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
   return {
-    title: 'Proposing special issues',
+    title: t('pages.proposingSpecialIssues.title', translations),
+    description: t('pages.proposingSpecialIssues.description', translations),
     alternates: generateSeoAlternates(journalId, lang, '/proposing-special-issues'),
   };
 }

--- a/src/app/sites/[journalId]/[lang]/search/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/search/page.tsx
@@ -18,9 +18,10 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
   return {
-    title: 'Recherche',
-    description: 'Rechercher des articles dans la revue',
+    title: t('pages.search.title', translations),
+    description: t('pages.search.description', translations),
     alternates: generateSeoAlternates(journalId, lang, '/search'),
   };
 }
@@ -31,7 +32,6 @@ interface SearchPageProps {
 }
 
 export default async function SearchPage(props: SearchPageProps) {
-  // Déférer au runtime, pas de cache (résultats de recherche dynamiques par utilisateur)
   await connection();
 
   const [searchParams, params] = await Promise.all([props.searchParams, props.params]);

--- a/src/app/sites/[journalId]/[lang]/search/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/search/page.tsx
@@ -7,14 +7,23 @@ import { FetchedArticle } from '@/utils/article';
 import { SearchRange } from '@/utils/pagination';
 import { connection } from 'next/server';
 
+import { generateSeoAlternates } from '@/utils/seo';
+
 const SearchClient = dynamic(() => import('./SearchClient'), {
   loading: () => <div className="loader">Chargement...</div>,
 });
 
-export const metadata: Metadata = {
-  title: 'Recherche',
-  description: 'Rechercher des articles dans la revue',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  return {
+    title: 'Recherche',
+    description: 'Rechercher des articles dans la revue',
+    alternates: generateSeoAlternates(journalId, lang, '/search'),
+  };
+}
 
 interface SearchPageProps {
   params: Promise<{ lang: string; journalId: string }>;

--- a/src/app/sites/[journalId]/[lang]/sections/[id]/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/sections/[id]/page.tsx
@@ -1,11 +1,12 @@
 import { Metadata } from 'next';
-import { fetchSection, fetchSections, fetchSectionArticles } from '@/services/section';
+import { fetchSection, fetchSectionArticles } from '@/services/section';
 import SectionDetailsClient from './SectionDetailsClient';
 import { getLanguageFromParams } from '@/utils/language-utils';
 import { ISection, PartialSectionArticle } from '@/types/section';
 import { IArticle } from '@/types/article';
 import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getLocalizedContent } from '@/utils/content-fallback';
+import { generateSeoAlternates } from '@/utils/seo';
 
 // Section details change infrequently - long revalidation time
 // Use on-demand revalidation API for updates
@@ -19,30 +20,37 @@ export async function generateMetadata(props: {
   params: Promise<{ id: string; lang?: string; journalId: string }>;
 }): Promise<Metadata> {
   const params = await props.params;
+  const { id, journalId } = params;
+  const language = getLanguageFromParams(params);
   try {
-    if (params.id === 'no-sections-found') {
+    if (id === 'no-sections-found') {
       return {
         title: 'No sections found',
         description: 'No sections available for this journal',
       };
     }
 
-    const section = await fetchSection({ sid: params.id, rvcode: params.journalId });
+    const section = await fetchSection({ sid: id, rvcode: journalId });
     if (!section) {
-      return { title: 'Section Details', description: 'Section details page' };
+      return {
+        title: 'Section Details',
+        description: 'Section details page',
+        alternates: generateSeoAlternates(journalId, language, `/sections/${id}`),
+      };
     }
-    const sectionTitle = section.title?.en || section.title?.fr || `Section ${params.id}`;
+    const sectionTitle = section.title?.en || section.title?.fr || `Section ${id}`;
 
     return {
       title: `${sectionTitle} | Episciences`,
-      description:
-        section.description?.en || section.description?.fr || `Articles in ${sectionTitle}`,
+      description: section.description?.en || section.description?.fr || `Articles in ${sectionTitle}`,
+      alternates: generateSeoAlternates(journalId, language, `/sections/${id}`),
     };
   } catch (error) {
-    console.error(`Error generating metadata for section ${params.id}:`, error);
+    console.error(`Error generating metadata for section ${id}:`, error);
     return {
       title: 'Section Details',
       description: 'Section details page',
+      alternates: generateSeoAlternates(journalId, language, `/sections/${id}`),
     };
   }
 }

--- a/src/app/sites/[journalId]/[lang]/sections/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/sections/page.tsx
@@ -1,17 +1,14 @@
 import { Metadata } from 'next';
-import { Suspense } from 'react';
-
 import { fetchSections } from '@/services/section';
 import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
-
+import { generateSeoAlternates } from '@/utils/seo';
 import dynamic from 'next/dynamic';
-import Loader from '@/components/Loader/Loader';
 
 const SectionsClient = dynamic(() => import('./SectionsClient'));
 
-// Sections list updates moderately - daily revalidation is appropriate
+// Section list updates moderately - daily revalidation
 export const revalidate = 86400; // 24 hours
 
 // Pre-generate sections page for all journals at build time
@@ -28,28 +25,30 @@ export async function generateStaticParams() {
   return params;
 }
 
-export const metadata: Metadata = {
-  title: 'Sections',
-};
-
-const SECTIONS_PER_PAGE = 10;
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  return {
+    title: 'Sections',
+    alternates: generateSeoAlternates(journalId, lang, '/sections'),
+  };
+}
 
 export default async function SectionsPage(props: {
   params: Promise<{ lang: string; journalId: string }>;
 }) {
   const params = await props.params;
   const { lang, journalId } = params;
+
   try {
     if (!journalId) {
       throw new Error('journalId is not defined');
     }
 
-    const [sectionsData, translations] = await Promise.all([
-      fetchSections({
-        rvcode: journalId,
-        page: 1,
-        itemsPerPage: SECTIONS_PER_PAGE,
-      }),
+    const [sections, translations] = await Promise.all([
+      fetchSections({ rvcode: journalId }),
       getServerTranslations(lang),
     ]);
 
@@ -60,14 +59,12 @@ export default async function SectionsPage(props: {
     };
 
     return (
-      <Suspense fallback={<Loader />}>
-        <SectionsClient
-          initialSections={sectionsData}
-          initialPage={1}
-          lang={lang}
-          breadcrumbLabels={breadcrumbLabels}
-        />
-      </Suspense>
+      <SectionsClient
+        initialSections={sections}
+        initialPage={1}
+        lang={lang}
+        breadcrumbLabels={breadcrumbLabels}
+      />
     );
   } catch (error) {
     console.error('Error fetching sections:', error);

--- a/src/app/sites/[journalId]/[lang]/sections/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/sections/page.tsx
@@ -30,8 +30,10 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
   return {
-    title: 'Sections',
+    title: t('pages.sections.title', translations),
+    description: t('pages.sections.description', translations),
     alternates: generateSeoAlternates(journalId, lang, '/sections'),
   };
 }

--- a/src/app/sites/[journalId]/[lang]/statistics/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/statistics/page.tsx
@@ -32,9 +32,10 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
   return {
-    title: 'Statistiques',
-    description: 'Statistiques de la revue',
+    title: t('pages.statistics.title', translations),
+    description: t('pages.statistics.description', translations),
     alternates: generateSeoAlternates(journalId, lang, '/statistics'),
   };
 }

--- a/src/app/sites/[journalId]/[lang]/statistics/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/statistics/page.tsx
@@ -4,6 +4,7 @@ import { fetchStatistics } from '@/services/statistics';
 import { getServerTranslations, t } from '@/utils/server-i18n';
 import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
+import { generateSeoAlternates } from '@/utils/seo';
 import type { IStatResponse } from '@/types/stat';
 import './Statistics.scss';
 
@@ -26,10 +27,17 @@ export async function generateStaticParams() {
   return params;
 }
 
-export const metadata: Metadata = {
-  title: 'Statistiques',
-  description: 'Statistiques de la revue',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  return {
+    title: 'Statistiques',
+    description: 'Statistiques de la revue',
+    alternates: generateSeoAlternates(journalId, lang, '/statistics'),
+  };
+}
 
 type Props = {
   params: Promise<{ journalId: string; lang: string }>;

--- a/src/app/sites/[journalId]/[lang]/volumes/VolumesClient.test.tsx
+++ b/src/app/sites/[journalId]/[lang]/volumes/VolumesClient.test.tsx
@@ -19,8 +19,9 @@ vi.mock('next/navigation', () => ({
   useRouter: vi.fn(() => ({
     push: vi.fn(),
   })),
-  usePathname: () => '/volumes',
-  useSearchParams: () => new URLSearchParams(),
+  useParams: vi.fn(() => ({})),
+  usePathname: vi.fn(() => '/volumes'),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
 }));
 
 vi.mock('@/hooks/store', () => ({

--- a/src/app/sites/[journalId]/[lang]/volumes/[id]/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/volumes/[id]/page.tsx
@@ -4,6 +4,7 @@ import { fetchArticle } from '@/services/article';
 import { getLanguageFromParams } from '@/utils/language-utils';
 import { FetchedArticle } from '@/utils/article';
 import { getServerTranslations, t } from '@/utils/server-i18n';
+import { generateSeoAlternates } from '@/utils/seo';
 import VolumeDetailsClient from './VolumeDetailsClient';
 
 // Volume details rarely change after publication - long revalidation time
@@ -14,9 +15,18 @@ export async function generateStaticParams() {
   return [];
 }
 
-export const metadata: Metadata = {
-  title: 'Volume Details',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ id: string; lang?: string; journalId: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { id, journalId } = params;
+  const language = getLanguageFromParams(params);
+
+  return {
+    title: 'Volume Details',
+    alternates: generateSeoAlternates(journalId, language, `/volumes/${id}`),
+  };
+}
 
 export default async function VolumeDetailsPage(props: {
   params: Promise<{ id: string; lang?: string; journalId: string }>;

--- a/src/app/sites/[journalId]/[lang]/volumes/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/volumes/page.tsx
@@ -9,6 +9,8 @@ import dynamic from 'next/dynamic';
 import { Suspense } from 'react';
 import Loader from '@/components/Loader/Loader';
 
+import { generateSeoAlternates } from '@/utils/seo';
+
 const VolumesClient = dynamic(() => import('./VolumesClient'));
 
 const VOLUMES_PER_PAGE = 20;
@@ -30,9 +32,16 @@ export async function generateStaticParams() {
   return params;
 }
 
-export const metadata: Metadata = {
-  title: 'Volumes',
-};
+export async function generateMetadata(props: {
+  params: Promise<{ journalId: string; lang: string }>;
+}): Promise<Metadata> {
+  const params = await props.params;
+  const { journalId, lang } = params;
+  return {
+    title: 'Volumes',
+    alternates: generateSeoAlternates(journalId, lang, '/volumes'),
+  };
+}
 
 export default async function VolumesPage(props: {
   params: Promise<{ lang: string; journalId: string }>;

--- a/src/app/sites/[journalId]/[lang]/volumes/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/volumes/page.tsx
@@ -37,8 +37,10 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const { journalId, lang } = params;
+  const translations = await getServerTranslations(lang);
   return {
-    title: 'Volumes',
+    title: t('pages.volumes.title', translations),
+    description: t('pages.volumes.description', translations),
     alternates: generateSeoAlternates(journalId, lang, '/volumes'),
   };
 }

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -2,6 +2,9 @@
 
 import { Link } from '@/components/Link/Link';
 import MathJax from '@/components/MathJax/MathJax';
+import { getLocalizedPath } from '@/utils/language-utils';
+import { getJournalBaseUrl } from '@/utils/signposting';
+import { useParams } from 'next/navigation';
 import './Breadcrumb.scss';
 
 interface IBreadcrumbProps {
@@ -18,24 +21,82 @@ export default function Breadcrumb({
   crumbLabel,
   lang,
 }: IBreadcrumbProps): React.JSX.Element {
+  const params = useParams();
+  const journalId = (params?.journalId as string) || '';
+
+  // JSON-LD Structured Data
+  const generateJsonLd = () => {
+    if (!journalId) return null;
+
+    const baseUrl = getJournalBaseUrl(journalId);
+    const currentLang = lang || 'en';
+
+    const items = [
+      ...parents.map((parent, index) => {
+        const cleanLabel = parent.label.replace(/\s*>\s*$/, '').trim();
+        let itemUrl = '';
+
+        if (parent.path === '#') {
+          // If no path, we don't include it in JSON-LD or we use the current page (less ideal)
+          return null;
+        } else if (parent.path.startsWith('http')) {
+          itemUrl = parent.path;
+        } else {
+          itemUrl = `${baseUrl}${getLocalizedPath(parent.path, currentLang)}`;
+        }
+
+        return {
+          '@type': 'ListItem',
+          position: index + 1,
+          name: cleanLabel,
+          item: itemUrl,
+        };
+      }),
+      {
+        '@type': 'ListItem',
+        position: parents.length + 1,
+        name: crumbLabel,
+        // The last item usually doesn't need a URL or can point to the current page,
+        // but for breadcrumbs, it's better to provide it if possible.
+        // However, we don't have the current full path here easily.
+      },
+    ].filter(Boolean);
+
+    const jsonLd = {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: items,
+    };
+
+    return (
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    );
+  };
+
   return (
-    <nav className="breadcrumb" aria-label="Breadcrumb">
-      <ol>
-        {parents.map((parent, index) => (
-          <li key={index} className="breadcrumb-parent">
-            {parent.path === '#' ? (
-              <span>{parent.label}</span>
-            ) : (
-              <Link href={`${parent.path}`} lang={lang}>
-                {parent.label}
-              </Link>
-            )}
+    <>
+      {generateJsonLd()}
+      <nav className="breadcrumb" aria-label="Breadcrumb">
+        <ol>
+          {parents.map((parent, index) => (
+            <li key={index} className="breadcrumb-parent">
+              {parent.path === '#' ? (
+                <span>{parent.label}</span>
+              ) : (
+                <Link href={`${parent.path}`} lang={lang}>
+                  {parent.label}
+                </Link>
+              )}
+            </li>
+          ))}
+          <li className="breadcrumb-current" aria-current="page">
+            <MathJax dynamic>{crumbLabel}</MathJax>
           </li>
-        ))}
-        <li className="breadcrumb-current" aria-current="page">
-          <MathJax dynamic>{crumbLabel}</MathJax>
-        </li>
-      </ol>
-    </nav>
+        </ol>
+      </nav>
+    </>
   );
 }

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -4,7 +4,7 @@ import { Link } from '@/components/Link/Link';
 import MathJax from '@/components/MathJax/MathJax';
 import { getLocalizedPath } from '@/utils/language-utils';
 import { getJournalBaseUrl } from '@/utils/signposting';
-import { useParams } from 'next/navigation';
+import { useParams, usePathname } from 'next/navigation';
 import './Breadcrumb.scss';
 
 interface IBreadcrumbProps {
@@ -23,6 +23,7 @@ export default function Breadcrumb({
 }: IBreadcrumbProps): React.JSX.Element {
   const params = useParams();
   const journalId = (params?.journalId as string) || '';
+  const pathname = usePathname();
 
   // JSON-LD Structured Data
   const generateJsonLd = () => {
@@ -56,9 +57,7 @@ export default function Breadcrumb({
         '@type': 'ListItem',
         position: parents.length + 1,
         name: crumbLabel,
-        // The last item usually doesn't need a URL or can point to the current page,
-        // but for breadcrumbs, it's better to provide it if possible.
-        // However, we don't have the current full path here easily.
+        item: pathname ? `${baseUrl}${pathname}` : undefined,
       },
     ].filter(Boolean);
 

--- a/src/components/Breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -1,6 +1,20 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useParams, usePathname } from 'next/navigation';
 import Breadcrumb from '../Breadcrumb';
+
+vi.mock('next/navigation', () => ({
+  useParams: vi.fn(() => ({})),
+  usePathname: vi.fn(() => null),
+}));
+
+vi.mock('@/utils/signposting', () => ({
+  getJournalBaseUrl: (id: string) => `https://${id}.episciences.org`,
+}));
+
+vi.mock('@/utils/language-utils', () => ({
+  getLocalizedPath: (path: string, lang: string) => `/${lang}${path}`,
+}));
 
 // Mock the Link component
 vi.mock('@/components/Link/Link', () => ({
@@ -172,5 +186,79 @@ describe('Breadcrumb', () => {
 
     expect(screen.getByText('Home & Articles >')).toBeInTheDocument();
     expect(screen.getByText('Authors & Reviewers')).toBeInTheDocument();
+  });
+});
+
+describe('JSON-LD structured data', () => {
+  beforeEach(() => {
+    vi.mocked(useParams).mockReturnValue({ journalId: 'test-journal' });
+    vi.mocked(usePathname).mockReturnValue('/en/volumes');
+  });
+
+  const getJsonLd = (container: HTMLElement) => {
+    const script = container.querySelector('script[type="application/ld+json"]');
+    if (!script) return null;
+    return JSON.parse(script.innerHTML);
+  };
+
+  it('renders a JSON-LD script when journalId is present', () => {
+    const parents = [{ path: '/', label: 'Home >' }];
+    const { container } = render(<Breadcrumb parents={parents} crumbLabel="Volumes" />);
+    expect(container.querySelector('script[type="application/ld+json"]')).toBeInTheDocument();
+  });
+
+  it('outputs BreadcrumbList schema type', () => {
+    const parents = [{ path: '/', label: 'Home >' }];
+    const { container } = render(<Breadcrumb parents={parents} crumbLabel="Volumes" />);
+    const jsonLd = getJsonLd(container);
+    expect(jsonLd['@context']).toBe('https://schema.org');
+    expect(jsonLd['@type']).toBe('BreadcrumbList');
+  });
+
+  it('assigns sequential 1-based positions to items', () => {
+    const parents = [
+      { path: '/', label: 'Home >' },
+      { path: '/volumes', label: 'Volumes >' },
+    ];
+    const { container } = render(<Breadcrumb parents={parents} crumbLabel="Vol. 1" />);
+    const items = getJsonLd(container).itemListElement;
+    expect(items[0].position).toBe(1);
+    expect(items[1].position).toBe(2);
+    expect(items[2].position).toBe(3);
+  });
+
+  it('sets the last item URL from usePathname', () => {
+    const parents = [{ path: '/', label: 'Home >' }];
+    const { container } = render(<Breadcrumb parents={parents} crumbLabel="Volumes" />);
+    const items = getJsonLd(container).itemListElement;
+    const lastItem = items[items.length - 1];
+    expect(lastItem.item).toBe('https://test-journal.episciences.org/en/volumes');
+  });
+
+  it('filters out items with path === "#"', () => {
+    const parents = [
+      { path: '/', label: 'Home >' },
+      { path: '#', label: 'Publish >' },
+    ];
+    const { container } = render(<Breadcrumb parents={parents} crumbLabel="For Authors" />);
+    const items = getJsonLd(container).itemListElement;
+    const names = items.map((i: { name: string }) => i.name);
+    expect(names).not.toContain('Publish >');
+  });
+
+  it('does not render a JSON-LD script when journalId is absent', () => {
+    vi.mocked(useParams).mockReturnValue({});
+    const parents = [{ path: '/', label: 'Home >' }];
+    const { container } = render(<Breadcrumb parents={parents} crumbLabel="Volumes" />);
+    expect(container.querySelector('script[type="application/ld+json"]')).not.toBeInTheDocument();
+  });
+
+  it('sets last item item to undefined when pathname is null', () => {
+    vi.mocked(usePathname).mockReturnValue(null);
+    const parents = [{ path: '/', label: 'Home >' }];
+    const { container } = render(<Breadcrumb parents={parents} crumbLabel="Volumes" />);
+    const items = getJsonLd(container).itemListElement;
+    const lastItem = items[items.length - 1];
+    expect(lastItem.item).toBeUndefined();
   });
 });

--- a/src/components/Meta/ArticleMeta/ArticleMeta.tsx
+++ b/src/components/Meta/ArticleMeta/ArticleMeta.tsx
@@ -91,10 +91,12 @@ export function generateArticleMetadata({
       name: author.fullname,
       url: author.orcid,
     })),
-    alternates: {
-      canonical: canonicalUrl,
-      languages: alternateLanguages,
-    },
+    ...(canonicalUrl && {
+      alternates: {
+        canonical: canonicalUrl,
+        languages: alternateLanguages,
+      },
+    }),
     openGraph: {
       title: metadataTitle || '',
       type: 'article',

--- a/src/components/Meta/ArticleMeta/ArticleMeta.tsx
+++ b/src/components/Meta/ArticleMeta/ArticleMeta.tsx
@@ -13,6 +13,8 @@ interface IArticleMetaProps {
   authors: IArticleAuthor[];
   coarInboxUrl?: string;
   relatedVolume?: IVolume | null;
+  canonicalUrl?: string;
+  alternateLanguages?: Record<string, string>;
 }
 
 // Helper function to extract abstract as string
@@ -38,6 +40,8 @@ export function generateArticleMetadata({
   authors,
   coarInboxUrl,
   relatedVolume,
+  canonicalUrl,
+  alternateLanguages,
 }: IArticleMetaProps): Metadata {
   const metadataTitle = article?.title
     ? `${article.title}${currentJournal?.name ? ` | ${currentJournal.name}` : ''}`
@@ -87,6 +91,10 @@ export function generateArticleMetadata({
       name: author.fullname,
       url: author.orcid,
     })),
+    alternates: {
+      canonical: canonicalUrl,
+      languages: alternateLanguages,
+    },
     openGraph: {
       title: metadataTitle || '',
       type: 'article',
@@ -95,7 +103,7 @@ export function generateArticleMetadata({
       authors: authors.map(author => author.fullname),
       tags: keywords,
       locale: language,
-      url: article?.docLink || '',
+      url: canonicalUrl || article?.docLink || '',
       description: abstractString,
       siteName: 'Episciences.org',
     },

--- a/src/utils/__tests__/seo.test.ts
+++ b/src/utils/__tests__/seo.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { generateSeoAlternates } from '../seo';
+
+vi.mock('../signposting', () => ({
+  getJournalBaseUrl: (id: string) => `https://${id}.episciences.org`,
+}));
+
+vi.mock('../language-utils', () => ({
+  acceptedLanguages: ['en', 'fr'],
+}));
+
+describe('generateSeoAlternates', () => {
+  describe('canonical URL', () => {
+    it('builds canonical with language prefix and path', () => {
+      const result = generateSeoAlternates('myjournal', 'en', '/volumes');
+      expect(result?.canonical).toBe('https://myjournal.episciences.org/en/volumes');
+    });
+
+    it('adds leading slash when path has none', () => {
+      const result = generateSeoAlternates('myjournal', 'fr', 'articles');
+      expect(result?.canonical).toBe('https://myjournal.episciences.org/fr/articles');
+    });
+
+    it('handles root path without double slash', () => {
+      const result = generateSeoAlternates('myjournal', 'en', '/');
+      expect(result?.canonical).toBe('https://myjournal.episciences.org/en');
+    });
+
+    it('uses current language in canonical URL', () => {
+      const resultEn = generateSeoAlternates('myjournal', 'en', '/about');
+      const resultFr = generateSeoAlternates('myjournal', 'fr', '/about');
+      expect(resultEn?.canonical).toContain('/en/');
+      expect(resultFr?.canonical).toContain('/fr/');
+    });
+  });
+
+  describe('alternate languages', () => {
+    it('generates alternates for all accepted languages', () => {
+      const result = generateSeoAlternates('myjournal', 'en', '/about');
+      const languages = result?.languages as Record<string, string>;
+      expect(Object.keys(languages)).toEqual(['en', 'fr']);
+    });
+
+    it('builds correct URL for each language', () => {
+      const result = generateSeoAlternates('myjournal', 'en', '/about');
+      const languages = result?.languages as Record<string, string>;
+      expect(languages['en']).toBe('https://myjournal.episciences.org/en/about');
+      expect(languages['fr']).toBe('https://myjournal.episciences.org/fr/about');
+    });
+
+    it('handles root path in language alternates without double slash', () => {
+      const result = generateSeoAlternates('myjournal', 'en', '/');
+      const languages = result?.languages as Record<string, string>;
+      expect(languages['en']).toBe('https://myjournal.episciences.org/en');
+      expect(languages['fr']).toBe('https://myjournal.episciences.org/fr');
+    });
+
+    it('uses journal-specific base URL', () => {
+      const result = generateSeoAlternates('diamond', 'en', '/volumes');
+      const languages = result?.languages as Record<string, string>;
+      expect(languages['en']).toContain('diamond.episciences.org');
+    });
+  });
+});

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,0 +1,31 @@
+import { Metadata } from 'next';
+import { getJournalBaseUrl } from './signposting';
+import { acceptedLanguages } from './language-utils';
+
+/**
+ * Generates SEO alternates (canonical and language variants) for Next.js Metadata
+ * @param journalId - The journal code
+ * @param currentLang - The current language
+ * @param pathWithoutLang - The path without language prefix (e.g., '/volumes/123')
+ * @returns Metadata['alternates'] object
+ */
+export function generateSeoAlternates(
+  journalId: string,
+  currentLang: string,
+  pathWithoutLang: string
+): Metadata['alternates'] {
+  const baseUrl = getJournalBaseUrl(journalId);
+  const cleanPath = pathWithoutLang.startsWith('/') ? pathWithoutLang : `/${pathWithoutLang}`;
+
+  const canonicalUrl = `${baseUrl}/${currentLang}${cleanPath === '/' ? '' : cleanPath}`;
+
+  const alternateLanguages: Record<string, string> = {};
+  acceptedLanguages.forEach(lang => {
+    alternateLanguages[lang] = `${baseUrl}/${lang}${cleanPath === '/' ? '' : cleanPath}`;
+  });
+
+  return {
+    canonical: canonicalUrl,
+    languages: alternateLanguages,
+  };
+}


### PR DESCRIPTION
## Description
This PR addresses SEO issues reported in Google Search Console (Duplicate without user-selected canonical) and improves search engine visibility across the platform.

### Key Changes:
1. Canonical URLs: Explicitly declares the Episciences URL as the authoritative version for all pages (Articles, Volumes, Static pages), preventing Google from selecting external repositories (arXiv/HAL) as canonical.
2. Multilingual SEO (hreflang): Adds rel=alternate tags for all supported languages on every page, helping Google serve the correct language version to users.
3. Structured Data (JSON-LD): Implements JSON-LD BreadcrumbList in the Breadcrumb component for cleaner rich snippets in search results.
4. OpenGraph Fixes: Corrects og:url to point to the journal site rather than the source repository.
5. Centralized Helper: Introduces src/utils/seo.ts to manage SEO metadata consistently across the application.

### Validation:
- Verified build with npm run build.
- Fixed multiple TypeScript and import issues discovered during the global rollout.