### PR TITLE
feat(seo): Schema.org JSON-LD structured data for all journal pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,11 @@ Instructions for AI assistants working with this repository.
 
 Next.js 16 (React 19) multi-tenant application for Episciences academic journals (45+ journals).
 
+<!-- BEGIN:nextjs-agent-rules -->
+# Next.js: ALWAYS read docs before coding
+Before any Next.js work, find and read the relevant doc in `node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.
+<!-- END:nextjs-agent-rules -->
+
 - **Architecture**: Node.js server with ISR (Incremental Static Regeneration)
 - **Routing**: Middleware maps hostnames to journal codes → `/sites/[journalId]/[lang]/...`
 - **Rendering**: Server Components for data/SEO, Client Components for interactivity
@@ -20,6 +25,7 @@ npm run test         # Run tests (Vitest)
 npm run test:coverage # Run tests with coverage
 npm run lint         # Linter (ESLint)
 npm run format       # Format code (Prettier)
+npm run validate:pages # Validate ISR page configurations
 make build && make up # Test with Nginx (production-like)
 ```
 
@@ -100,6 +106,8 @@ Use semantic CSS variables for text colors (WCAG compliance):
 | ----------------------- | --------------------------------- |
 | ISR & Caching           | `docs/ISR_STRATEGY.md`            |
 | Webhooks & Revalidation | `docs/REVALIDATION_GUIDE.md`      |
+| Revalidation Specs (Symfony) | `docs/REVALIDATION_IMPLEMENTATION_SPEC_SYMFONY.md` |
+| Revalidation Specs (ZF1) | `docs/REVALIDATION_IMPLEMENTATION_SPEC_ZF1.md` |
 | Runtime Configuration   | `docs/CONFIGURATION_GUIDE.md`     |
 | Local Testing           | `docs/LOCAL_TESTING_GUIDE.md`     |
 | Nginx & Docker          | `docs/NGINX_INTEGRATION.md`       |

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "prettier": "^3.8.3",
         "sass": "^1.99.0",
         "sass-loader": "^16.0.5",
+        "tsx": "^4.22.4",
         "typescript": "^5.2.2",
         "vitest": "^4.1.6",
         "vitest-axe": "^0.1.0"
@@ -3422,6 +3423,448 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
       "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -8189,6 +8632,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -15207,6 +15692,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15372,9 +15372,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "prettier": "^3.8.3",
     "sass": "^1.99.0",
     "sass-loader": "^16.0.5",
+    "tsx": "^4.22.4",
     "typescript": "^5.2.2",
     "vitest": "^4.1.6",
     "vitest-axe": "^0.1.0"

--- a/src/app/sites/[journalId]/[lang]/[...slug]/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/[...slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation';
+import { connection } from 'next/server';
 
-export const dynamic = 'force-dynamic';
-
-export default function CatchAllPage() {
+export default async function CatchAllPage() {
+  await connection();
   notFound();
 }

--- a/src/app/sites/[journalId]/[lang]/about/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/about/page.tsx
@@ -7,6 +7,8 @@ import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
 import { generateSeoAlternates } from '@/utils/seo';
 import { logger } from '@/lib/logger';
+import JsonLd from '@/components/Meta/JsonLd';
+import { generateWebPageJsonLd } from '@/utils/schema';
 
 const AboutClient = dynamic(() => import('./AboutClient'));
 
@@ -71,5 +73,13 @@ export default async function AboutPage(props: {
     about: t('pages.about.title', translations),
   };
 
-  return <AboutClient initialPage={pageData} lang={lang} breadcrumbLabels={breadcrumbLabels} />;
+  return (
+    <>
+      <JsonLd data={generateWebPageJsonLd('AboutPage', journalId, lang, '/about', {
+        name: t('pages.about.title', translations),
+        lastReviewed: pageData?.date_updated,
+      })} />
+      <AboutClient initialPage={pageData} lang={lang} breadcrumbLabels={breadcrumbLabels} />
+    </>
+  );
 }

--- a/src/app/sites/[journalId]/[lang]/accessibility/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/accessibility/page.tsx
@@ -8,6 +8,8 @@ import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages, defaultLanguage } from '@/utils/language-utils';
 import { generateSeoAlternates } from '@/utils/seo';
 import { logger } from '@/lib/logger';
+import JsonLd from '@/components/Meta/JsonLd';
+import { generateWebPageJsonLd } from '@/utils/schema';
 
 export const revalidate = false;
 
@@ -43,7 +45,7 @@ export default async function AccessibilityPage(props: {
   params: Promise<{ journalId: string; lang: string }>;
 }) {
   const params = await props.params;
-  const { lang } = params;
+  const { journalId, lang } = params;
   const translations = await getServerTranslations(lang);
 
   const contentDir = path.join(process.cwd(), 'src/content/accessibility');
@@ -75,13 +77,18 @@ export default async function AccessibilityPage(props: {
   };
 
   return (
-    <MarkdownPageWithSidebar
-      content={content}
-      title={translate('pages.accessibility.title', translations)}
-      isLoading={false}
-      breadcrumbLabels={breadcrumbLabels}
-      lang={lang}
-      className="markdown-page"
-    />
+    <>
+      <JsonLd data={generateWebPageJsonLd('WebPage', journalId, lang, '/accessibility', {
+        name: translate('pages.accessibility.title', translations),
+      })} />
+      <MarkdownPageWithSidebar
+        content={content}
+        title={translate('pages.accessibility.title', translations)}
+        isLoading={false}
+        breadcrumbLabels={breadcrumbLabels}
+        lang={lang}
+        className="markdown-page"
+      />
+    </>
   );
 }

--- a/src/app/sites/[journalId]/[lang]/acknowledgements/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/acknowledgements/page.tsx
@@ -7,6 +7,8 @@ import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
 import { generateSeoAlternates } from '@/utils/seo';
 import { logger } from '@/lib/logger';
+import JsonLd from '@/components/Meta/JsonLd';
+import { generateWebPageJsonLd } from '@/utils/schema';
 
 const AcknowledgementsClient = dynamic(() => import('./AcknowledgementsClient'));
 
@@ -73,10 +75,15 @@ export default async function AcknowledgementsPage(props: {
   };
 
   return (
-    <AcknowledgementsClient
-      initialPage={pageData}
-      lang={lang}
-      breadcrumbLabels={breadcrumbLabels}
-    />
+    <>
+      <JsonLd data={generateWebPageJsonLd('WebPage', journalId, lang, '/acknowledgements', {
+        name: t('pages.acknowledgements.title', translations),
+      })} />
+      <AcknowledgementsClient
+        initialPage={pageData}
+        lang={lang}
+        breadcrumbLabels={breadcrumbLabels}
+      />
+    </>
   );
 }

--- a/src/app/sites/[journalId]/[lang]/articles/[id]/ArticleDetailsServer.tsx
+++ b/src/app/sites/[journalId]/[lang]/articles/[id]/ArticleDetailsServer.tsx
@@ -21,6 +21,8 @@ import ReferencesSection from './components/ReferencesSection';
 import PreviewSection from './components/PreviewSection';
 import CollapsibleSectionWrapper from './components/CollapsibleSectionWrapper';
 import SignpostingLinks from '@/components/SignpostingLinks/SignpostingLinks';
+import JsonLd from '@/components/Meta/JsonLd';
+import { generateScholarlyArticleJsonLd } from '@/utils/schema';
 import './ArticleDetails.scss';
 
 interface ArticleDetailsServerProps {
@@ -237,8 +239,11 @@ export default function ArticleDetailsServer({
     );
   };
 
+  const articleJsonLd = generateScholarlyArticleJsonLd(article, rvcode, language || defaultLanguage, relatedVolume);
+
   return (
     <>
+      <JsonLd data={articleJsonLd} />
       <SignpostingLinks article={article} rvcode={rvcode} id={id} lang={language || defaultLanguage} />
       <main className="articleDetails">
       <Breadcrumb

--- a/src/app/sites/[journalId]/[lang]/articles/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/articles/page.tsx
@@ -8,6 +8,8 @@ import { Suspense } from 'react';
 import Loader from '@/components/Loader/Loader';
 import { generateSeoAlternates } from '@/utils/seo';
 import { logger } from '@/lib/logger';
+import JsonLd from '@/components/Meta/JsonLd';
+import { generateCollectionPageJsonLd } from '@/utils/schema';
 
 const ArticlesClient = dynamic(() => import('./ArticlesClient'));
 
@@ -102,14 +104,20 @@ export default async function ArticlesPage(props: {
     };
 
     return (
-      <Suspense fallback={<Loader />}>
-        <ArticlesClient
-          initialArticles={formattedArticles}
-          lang={lang}
-          breadcrumbLabels={breadcrumbLabels}
-          countLabels={countLabels}
-        />
-      </Suspense>
+      <>
+        <JsonLd data={generateCollectionPageJsonLd(journalId, lang, '/articles', {
+          name: t('pages.articles.title', translations),
+          numberOfItems: formattedArticles.totalItems,
+        })} />
+        <Suspense fallback={<Loader />}>
+          <ArticlesClient
+            initialArticles={formattedArticles}
+            lang={lang}
+            breadcrumbLabels={breadcrumbLabels}
+            countLabels={countLabels}
+          />
+        </Suspense>
+      </>
     );
   } catch (error) {
     logger.error('Error fetching articles:', error);

--- a/src/app/sites/[journalId]/[lang]/boards/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/boards/page.tsx
@@ -8,6 +8,8 @@ import { generateSeoAlternates } from '@/utils/seo';
 
 import dynamic from 'next/dynamic';
 import { logger } from '@/lib/logger';
+import JsonLd from '@/components/Meta/JsonLd';
+import { generateWebPageJsonLd } from '@/utils/schema';
 
 const BoardsClient = dynamic(() => import('./BoardsClient'));
 
@@ -94,15 +96,20 @@ export default async function BoardsPage(props: {
     const tableOfContentsLabel = t('pages.boards.tableOfContents', translations);
 
     return (
-      <BoardsClient
-        initialPages={pages}
-        initialMembers={members}
-        lang={lang}
-        breadcrumbLabels={breadcrumbLabels}
-        membersCountLabels={membersCountLabels}
-        rolesLabels={rolesLabels}
-        tableOfContentsLabel={tableOfContentsLabel}
-      />
+      <>
+        <JsonLd data={generateWebPageJsonLd('WebPage', journalId, lang, '/boards', {
+          name: t('pages.boards.title', translations),
+        })} />
+        <BoardsClient
+          initialPages={pages}
+          initialMembers={members}
+          lang={lang}
+          breadcrumbLabels={breadcrumbLabels}
+          membersCountLabels={membersCountLabels}
+          rolesLabels={rolesLabels}
+          tableOfContentsLabel={tableOfContentsLabel}
+        />
+      </>
     );
   } catch (error) {
     logger.warn(

--- a/src/app/sites/[journalId]/[lang]/credits/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/credits/page.tsx
@@ -7,6 +7,8 @@ import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
 import { generateSeoAlternates } from '@/utils/seo';
 import { logger } from '@/lib/logger';
+import JsonLd from '@/components/Meta/JsonLd';
+import { generateWebPageJsonLd } from '@/utils/schema';
 
 const CreditsClient = dynamic(() => import('./CreditsClient'));
 
@@ -65,5 +67,12 @@ export default async function CreditsPage(props: {
     credits: t('pages.credits.title', translations),
   };
 
-  return <CreditsClient creditsPage={pageData} lang={lang} breadcrumbLabels={breadcrumbLabels} />;
+  return (
+    <>
+      <JsonLd data={generateWebPageJsonLd('WebPage', journalId, lang, '/credits', {
+        name: t('pages.credits.title', translations),
+      })} />
+      <CreditsClient creditsPage={pageData} lang={lang} breadcrumbLabels={breadcrumbLabels} />
+    </>
+  );
 }

--- a/src/app/sites/[journalId]/[lang]/ethical-charter/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/ethical-charter/page.tsx
@@ -7,6 +7,8 @@ import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
 import { generateSeoAlternates } from '@/utils/seo';
 import { logger } from '@/lib/logger';
+import JsonLd from '@/components/Meta/JsonLd';
+import { generateWebPageJsonLd } from '@/utils/schema';
 
 const EthicalCharterClient = dynamic(() => import('./EthicalCharterClient'));
 
@@ -65,6 +67,11 @@ export default async function EthicalCharterPage(props: {
   };
 
   return (
-    <EthicalCharterClient initialPage={pageData} lang={lang} breadcrumbLabels={breadcrumbLabels} />
+    <>
+      <JsonLd data={generateWebPageJsonLd('WebPage', journalId, lang, '/ethical-charter', {
+        name: t('pages.ethicalCharter.title', translations),
+      })} />
+      <EthicalCharterClient initialPage={pageData} lang={lang} breadcrumbLabels={breadcrumbLabels} />
+    </>
   );
 }

--- a/src/app/sites/[journalId]/[lang]/for-authors/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/for-authors/page.tsx
@@ -8,6 +8,8 @@ import { acceptedLanguages } from '@/utils/language-utils';
 
 import { generateSeoAlternates } from '@/utils/seo';
 import { logger } from '@/lib/logger';
+import JsonLd from '@/components/Meta/JsonLd';
+import { generateWebPageJsonLd } from '@/utils/schema';
 
 const ForAuthorsClient = dynamic(() => import('./ForAuthorsClient'));
 
@@ -73,11 +75,16 @@ export default async function ForAuthorsPage(props: {
   };
 
   return (
-    <ForAuthorsClient
-      editorialWorkflowPage={editorialWorkflowPage}
-      prepareSubmissionPage={prepareSubmissionPage}
-      lang={lang}
-      breadcrumbLabels={breadcrumbLabels}
-    />
+    <>
+      <JsonLd data={generateWebPageJsonLd('WebPage', journalId, lang, '/for-authors', {
+        name: t('pages.forAuthors.title', translations),
+      })} />
+      <ForAuthorsClient
+        editorialWorkflowPage={editorialWorkflowPage}
+        prepareSubmissionPage={prepareSubmissionPage}
+        lang={lang}
+        breadcrumbLabels={breadcrumbLabels}
+      />
+    </>
   );
 }

--- a/src/app/sites/[journalId]/[lang]/for-conference-organisers/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/for-conference-organisers/page.tsx
@@ -9,6 +9,8 @@ import { acceptedLanguages } from '@/utils/language-utils';
 import { getPublicJournalConfig } from '@/utils/env-loader';
 import { generateSeoAlternates } from '@/utils/seo';
 import { logger } from '@/lib/logger';
+import JsonLd from '@/components/Meta/JsonLd';
+import { generateWebPageJsonLd } from '@/utils/schema';
 
 const ForConferenceOrganisersClient = dynamic(() => import('./ForConferenceOrganisersClient'));
 
@@ -73,10 +75,15 @@ export default async function ForConferenceOrganisersPage(props: {
   };
 
   return (
-    <ForConferenceOrganisersClient
-      initialPage={pageData}
-      lang={lang}
-      breadcrumbLabels={breadcrumbLabels}
-    />
+    <>
+      <JsonLd data={generateWebPageJsonLd('WebPage', journalId, lang, '/for-conference-organisers', {
+        name: t('pages.forConferenceOrganisers.title', translations),
+      })} />
+      <ForConferenceOrganisersClient
+        initialPage={pageData}
+        lang={lang}
+        breadcrumbLabels={breadcrumbLabels}
+      />
+    </>
   );
 }

--- a/src/app/sites/[journalId]/[lang]/for-reviewers/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/for-reviewers/page.tsx
@@ -9,6 +9,8 @@ import { acceptedLanguages } from '@/utils/language-utils';
 import { getPublicJournalConfig } from '@/utils/env-loader';
 import { generateSeoAlternates } from '@/utils/seo';
 import { logger } from '@/lib/logger';
+import JsonLd from '@/components/Meta/JsonLd';
+import { generateWebPageJsonLd } from '@/utils/schema';
 
 const ForReviewersClient = dynamic(() => import('./ForReviewersClient'));
 
@@ -73,6 +75,11 @@ export default async function ForReviewersPage(props: {
   };
 
   return (
-    <ForReviewersClient initialPage={pageData} lang={lang} breadcrumbLabels={breadcrumbLabels} />
+    <>
+      <JsonLd data={generateWebPageJsonLd('WebPage', journalId, lang, '/for-reviewers', {
+        name: t('pages.forReviewers.title', translations),
+      })} />
+      <ForReviewersClient initialPage={pageData} lang={lang} breadcrumbLabels={breadcrumbLabels} />
+    </>
   );
 }

--- a/src/app/sites/[journalId]/[lang]/indexing/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/indexing/page.tsx
@@ -7,6 +7,8 @@ import { getFilteredJournals } from '@/utils/journal-filter';
 import { acceptedLanguages } from '@/utils/language-utils';
 import { generateSeoAlternates } from '@/utils/seo';
 import { logger } from '@/lib/logger';
+import JsonLd from '@/components/Meta/JsonLd';
+import { generateWebPageJsonLd } from '@/utils/schema';
 
 const IndexingClient = dynamic(() => import('./IndexingClient'));
 
@@ -65,6 +67,11 @@ export default async function IndexingPage(props: {
   };
 
   return (
-    <IndexingClient initialPage={pageData} lang={lang} breadcrumbLabels={breadcrumbLabels} />
+    <>
+      <JsonLd data={generateWebPageJsonLd('WebPage', journalId, lang, '/indexing', {
+        name: t('pages.indexing.title', translations),
+      })} />
+      <IndexingClient initialPage={pageData} lang={lang} breadcrumbLabels={breadcrumbLabels} />
+    </>
   );
 }

--- a/src/app/sites/[journalId]/[lang]/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import { fetchHomeData } from '@/services/home';
+import { getJournalByCode } from '@/services/journal';
 import { getFormattedSiteTitle } from '@/utils/metadata';
 import { getServerTranslations, t } from '@/utils/server-i18n';
 import { acceptedLanguages } from '@/utils/language-utils';
@@ -7,6 +8,8 @@ import { getFilteredJournals } from '@/utils/journal-filter';
 import dynamicImport from 'next/dynamic';
 import { generateSeoAlternates } from '@/utils/seo';
 import { getPublicJournalConfig } from '@/utils/env-loader';
+import JsonLd from '@/components/Meta/JsonLd';
+import { generateHomepageJsonLd } from '@/utils/schema';
 import '@/styles/pages/Home.scss';
 import { logger } from '@/lib/logger';
 
@@ -42,11 +45,6 @@ export async function generateMetadata(props: {
   };
 }
 
-// Fonction pour obtenir la langue par défaut
-function getDefaultLanguage(): string {
-  return process.env.NEXT_PUBLIC_DEFAULT_LANGUAGE || 'fr';
-}
-
 export default async function HomePage(props: {
   params: Promise<{ journalId: string; lang: string }>;
 }) {
@@ -54,15 +52,23 @@ export default async function HomePage(props: {
   const language = params.lang || 'fr';
   const rvcode = params.journalId;
 
-  let homeData = {};
-
-  try {
-    homeData = await fetchHomeData(rvcode, language);
-  } catch (error) {
-    logger.error(`Error fetching home data for journal ${rvcode}:`, error);
-  }
+  const [homeData, journal] = await Promise.all([
+    fetchHomeData(rvcode, language).catch((error: unknown) => {
+      logger.error(`Error fetching home data for journal ${rvcode}:`, error);
+      return {};
+    }),
+    getJournalByCode(rvcode).catch((error: unknown) => {
+      logger.error(`Error fetching journal for JSON-LD on homepage ${rvcode}:`, error);
+      return null;
+    }),
+  ]);
 
   const journalConfig = getPublicJournalConfig(rvcode);
 
-  return <HomeClient homeData={homeData} language={language} journalId={rvcode} journalConfig={journalConfig} />;
+  return (
+    <>
+      {journal && <JsonLd data={generateHomepageJsonLd(journal, rvcode, language)} />}
+      <HomeClient homeData={homeData} language={language} journalId={rvcode} journalConfig={journalConfig} />
+    </>
+  );
 }

--- a/src/app/sites/[journalId]/[lang]/statistics/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/statistics/page.tsx
@@ -8,6 +8,8 @@ import { generateSeoAlternates } from '@/utils/seo';
 import type { IStatResponse } from '@/types/stat';
 import './Statistics.scss';
 import { logger } from '@/lib/logger';
+import JsonLd from '@/components/Meta/JsonLd';
+import { generateWebPageJsonLd } from '@/utils/schema';
 
 const StatisticsClient = dynamic(() => import('./StatisticsClient'));
 
@@ -88,6 +90,11 @@ export default async function StatisticsPage(props: Props) {
   };
 
   return (
-    <StatisticsClient initialStats={initialStats} lang={lang} breadcrumbLabels={breadcrumbLabels} />
+    <>
+      <JsonLd data={generateWebPageJsonLd('WebPage', journalId, lang, '/statistics', {
+        name: t('pages.statistics.title', translations),
+      })} />
+      <StatisticsClient initialStats={initialStats} lang={lang} breadcrumbLabels={breadcrumbLabels} />
+    </>
   );
 }

--- a/src/app/sites/[journalId]/[lang]/volumes/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/volumes/page.tsx
@@ -11,6 +11,8 @@ import Loader from '@/components/Loader/Loader';
 
 import { generateSeoAlternates } from '@/utils/seo';
 import { logger } from '@/lib/logger';
+import JsonLd from '@/components/Meta/JsonLd';
+import { generateCollectionPageJsonLd } from '@/utils/schema';
 
 const VolumesClient = dynamic(() => import('./VolumesClient'));
 
@@ -185,17 +187,23 @@ export default async function VolumesPage(props: {
     };
 
     return (
-      <Suspense fallback={<Loader />}>
-        <VolumesClient
-          initialVolumes={finalVolumesData}
-          initialPage={validPage}
-          initialTypes={types}
-          initialYears={years}
-          lang={lang}
-          journalId={journalId}
-          breadcrumbLabels={breadcrumbLabels}
-        />
-      </Suspense>
+      <>
+        <JsonLd data={generateCollectionPageJsonLd(journalId, lang, '/volumes', {
+          name: t('pages.volumes.title', translations),
+          numberOfItems: finalVolumesData.totalItems,
+        })} />
+        <Suspense fallback={<Loader />}>
+          <VolumesClient
+            initialVolumes={finalVolumesData}
+            initialPage={validPage}
+            initialTypes={types}
+            initialYears={years}
+            lang={lang}
+            journalId={journalId}
+            breadcrumbLabels={breadcrumbLabels}
+          />
+        </Suspense>
+      </>
     );
   } catch (error) {
     logger.error('Error fetching volumes:', error);

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { Link } from '@/components/Link/Link';
+import JsonLd from '@/components/Meta/JsonLd';
 import MathJax from '@/components/MathJax/MathJax';
-import { getLocalizedPath } from '@/utils/language-utils';
-import { getJournalBaseUrl } from '@/utils/signposting';
+import { generateBreadcrumbJsonLd } from '@/utils/schema';
 import { useParams, usePathname } from 'next/navigation';
 import './Breadcrumb.scss';
 
@@ -24,60 +24,15 @@ export default function Breadcrumb({
   const params = useParams();
   const journalId = (params?.journalId as string) || '';
   const pathname = usePathname();
+  const currentLang = lang || 'en';
 
-  // JSON-LD Structured Data
-  const generateJsonLd = () => {
-    if (!journalId) return null;
-
-    const baseUrl = getJournalBaseUrl(journalId);
-    const currentLang = lang || 'en';
-
-    const items = [
-      ...parents.map((parent, index) => {
-        const cleanLabel = parent.label.replace(/\s*>\s*$/, '').trim();
-        let itemUrl = '';
-
-        if (parent.path === '#') {
-          // If no path, we don't include it in JSON-LD or we use the current page (less ideal)
-          return null;
-        } else if (parent.path.startsWith('http')) {
-          itemUrl = parent.path;
-        } else {
-          itemUrl = `${baseUrl}${getLocalizedPath(parent.path, currentLang)}`;
-        }
-
-        return {
-          '@type': 'ListItem',
-          position: index + 1,
-          name: cleanLabel,
-          item: itemUrl,
-        };
-      }),
-      {
-        '@type': 'ListItem',
-        position: parents.length + 1,
-        name: crumbLabel,
-        item: pathname ? `${baseUrl}${pathname}` : undefined,
-      },
-    ].filter(Boolean);
-
-    const jsonLd = {
-      '@context': 'https://schema.org',
-      '@type': 'BreadcrumbList',
-      itemListElement: items,
-    };
-
-    return (
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
-    );
-  };
+  const jsonLd = journalId
+    ? generateBreadcrumbJsonLd(parents, crumbLabel, currentLang, journalId, pathname)
+    : null;
 
   return (
     <>
-      {generateJsonLd()}
+      {jsonLd && <JsonLd data={jsonLd} />}
       <nav className="breadcrumb" aria-label="Breadcrumb">
         <ol>
           {parents.map((parent, index) => (

--- a/src/components/Breadcrumb/__tests__/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb/__tests__/Breadcrumb.test.tsx
@@ -261,4 +261,29 @@ describe('JSON-LD structured data', () => {
     const lastItem = items[items.length - 1];
     expect(lastItem.item).toBeUndefined();
   });
+
+  it('sets @id on the BreadcrumbList from pathname', () => {
+    const parents = [{ path: '/', label: 'Home >' }];
+    const { container } = render(<Breadcrumb parents={parents} crumbLabel="Volumes" />);
+    const jsonLd = getJsonLd(container);
+    expect(jsonLd['@id']).toBe('https://test-journal.episciences.org/en/volumes#breadcrumb');
+  });
+
+  it('omits @id when pathname is null', () => {
+    vi.mocked(usePathname).mockReturnValue(null);
+    const parents = [{ path: '/', label: 'Home >' }];
+    const { container } = render(<Breadcrumb parents={parents} crumbLabel="Volumes" />);
+    const jsonLd = getJsonLd(container);
+    expect(jsonLd['@id']).toBeUndefined();
+  });
+
+  it('escapes < in the raw script content to prevent </script> injection', () => {
+    const parents = [{ path: '/', label: 'Home >' }];
+    const { container } = render(
+      <Breadcrumb parents={parents} crumbLabel="</script><script>alert(1)</script>" />
+    );
+    const script = container.querySelector('script[type="application/ld+json"]');
+    expect(script?.innerHTML).not.toContain('</script>');
+    expect(script?.innerHTML).toContain('\\u003c');
+  });
 });

--- a/src/components/Header/__tests__/HeaderDropdown.test.tsx
+++ b/src/components/Header/__tests__/HeaderDropdown.test.tsx
@@ -210,7 +210,7 @@ describe('HeaderDropdown', () => {
       const lastItem = menuItems[items.length - 1];
 
       fireEvent.keyDown(lastItem, { key: 'ArrowDown' });
-      // No error thrown — cyclic navigation works
+      expect(document.activeElement).toBe(menuItems[0]);
     });
 
     it('ArrowUp on first item wraps to last', () => {
@@ -219,7 +219,7 @@ describe('HeaderDropdown', () => {
       const firstItem = menuItems[0];
 
       fireEvent.keyDown(firstItem, { key: 'ArrowUp' });
-      // No error thrown — cyclic navigation works
+      expect(document.activeElement).toBe(menuItems[items.length - 1]);
     });
 
     it('Escape on menu item closes the dropdown', () => {

--- a/src/components/MarkdownRenderer/__tests__/MarkdownRenderer.test.tsx
+++ b/src/components/MarkdownRenderer/__tests__/MarkdownRenderer.test.tsx
@@ -60,7 +60,8 @@ describe('MarkdownRenderer', () => {
 
     it('passes a11y checks for table', async () => {
       const { container } = render(<MarkdownRenderer>{TABLE_MARKDOWN}</MarkdownRenderer>);
-      await checkA11y(container);
+      const results = await checkA11y(container);
+      expect(results.violations).toHaveLength(0);
     });
   });
 

--- a/src/components/Meta/JsonLd.tsx
+++ b/src/components/Meta/JsonLd.tsx
@@ -1,10 +1,11 @@
+import type { JSX } from 'react';
 import type { SchemaOrgThing } from '@/utils/schema';
 
 interface JsonLdProps {
   data: SchemaOrgThing;
 }
 
-export default function JsonLd({ data }: JsonLdProps): React.JSX.Element {
+export default function JsonLd({ data }: JsonLdProps): JSX.Element {
   const serialized = JSON.stringify(data)
     .replace(/</g, '\\u003c')
     .replace(/>/g, '\\u003e')

--- a/src/components/Meta/JsonLd.tsx
+++ b/src/components/Meta/JsonLd.tsx
@@ -1,0 +1,19 @@
+import type { SchemaOrgThing } from '@/utils/schema';
+
+interface JsonLdProps {
+  data: SchemaOrgThing;
+}
+
+export default function JsonLd({ data }: JsonLdProps): React.JSX.Element {
+  const serialized = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: serialized }}
+    />
+  );
+}

--- a/src/components/Meta/__tests__/JsonLd.test.tsx
+++ b/src/components/Meta/__tests__/JsonLd.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import JsonLd from '../JsonLd';
+
+const getScript = (container: HTMLElement) =>
+  container.querySelector('script[type="application/ld+json"]');
+
+describe('JsonLd', () => {
+  it('renders a script tag with type application/ld+json', () => {
+    const data = { '@context': 'https://schema.org' as const, '@type': 'WebPage' };
+    const { container } = render(<JsonLd data={data} />);
+    expect(getScript(container)).toBeInTheDocument();
+  });
+
+  it('serializes data so JSON.parse recovers the original object', () => {
+    const data = {
+      '@context': 'https://schema.org' as const,
+      '@type': 'WebPage',
+      name: 'Test Page',
+    };
+    const { container } = render(<JsonLd data={data} />);
+    const script = getScript(container);
+    const parsed = JSON.parse(script?.innerHTML ?? '');
+    expect(parsed).toEqual(data);
+  });
+
+  it('escapes < to prevent </script> injection', () => {
+    const data = {
+      '@context': 'https://schema.org' as const,
+      '@type': 'WebPage',
+      name: '</script><script>alert("xss")</script>',
+    };
+    const { container } = render(<JsonLd data={data} />);
+    const script = getScript(container);
+    expect(script?.innerHTML).not.toContain('</script>');
+    expect(script?.innerHTML).toContain('\\u003c');
+  });
+
+  it('escapes > to \\u003e', () => {
+    const data = { '@context': 'https://schema.org' as const, '@type': 'WebPage', name: 'a>b' };
+    const { container } = render(<JsonLd data={data} />);
+    const script = getScript(container);
+    expect(script?.innerHTML).toContain('\\u003e');
+    expect(script?.innerHTML).not.toContain('"a>b"');
+  });
+
+  it('escapes & to \\u0026', () => {
+    const data = { '@context': 'https://schema.org' as const, '@type': 'WebPage', name: 'A&B' };
+    const { container } = render(<JsonLd data={data} />);
+    const script = getScript(container);
+    expect(script?.innerHTML).toContain('\\u0026');
+    expect(script?.innerHTML).not.toContain('"A&B"');
+  });
+
+  it('parsed output recovers original values despite escaping', () => {
+    const data = {
+      '@context': 'https://schema.org' as const,
+      '@type': 'WebPage',
+      name: '<Test & "Page">',
+    };
+    const { container } = render(<JsonLd data={data} />);
+    const script = getScript(container);
+    const parsed = JSON.parse(script?.innerHTML ?? '');
+    expect(parsed.name).toBe('<Test & "Page">');
+  });
+
+  it('renders @graph arrays correctly', () => {
+    const data = {
+      '@context': 'https://schema.org' as const,
+      '@graph': [
+        { '@type': 'WebSite', name: 'My Journal' },
+        { '@type': 'Periodical', name: 'My Journal' },
+      ],
+    };
+    const { container } = render(<JsonLd data={data} />);
+    const script = getScript(container);
+    const parsed = JSON.parse(script?.innerHTML ?? '');
+    expect(parsed['@graph']).toHaveLength(2);
+    expect(parsed['@graph'][0]['@type']).toBe('WebSite');
+  });
+});

--- a/src/hooks/__tests__/useMobileModal.test.tsx
+++ b/src/hooks/__tests__/useMobileModal.test.tsx
@@ -80,7 +80,7 @@ describe('useMobileModal', () => {
           typeof call[0] === 'object' &&
           call[0] !== null &&
           'payload' in call[0] &&
-          (call[0] as { payload: boolean }).payload === true
+          (call[0] as unknown as { payload: boolean }).payload === true
       );
       expect(setTrueCalls.length).toBeGreaterThanOrEqual(1);
     });

--- a/src/utils/__tests__/schema.test.ts
+++ b/src/utils/__tests__/schema.test.ts
@@ -1,0 +1,633 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  generateBreadcrumbJsonLd,
+  generateCollectionPageJsonLd,
+  generateHomepageJsonLd,
+  generateScholarlyArticleJsonLd,
+  generateWebPageJsonLd,
+  getWebSiteId,
+  getPeriodicalId,
+  getWebPageId,
+  getArticleId,
+} from '../schema';
+import type { IArticle } from '@/types/article';
+import type { IJournal } from '@/types/journal';
+import type { IVolume } from '@/types/volume';
+
+vi.mock('@/utils/signposting', () => ({
+  getJournalBaseUrl: (id: string) => `https://${id}.episciences.org`,
+}));
+
+vi.mock('@/utils/language-utils', () => ({
+  getLocalizedPath: (path: string, lang: string) => `/${lang}${path}`,
+}));
+
+const BASE = 'https://test-journal.episciences.org';
+
+// --- generateHomepageJsonLd ---
+
+const makeJournal = (overrides: Partial<IJournal> = {}): IJournal => ({
+  id: 1,
+  name: 'Test Journal',
+  code: 'test-journal',
+  settings: [],
+  title: { en: 'Test Journal', fr: 'Journal de test' } as any,
+  ...overrides,
+});
+
+describe('generateHomepageJsonLd', () => {
+  const graph = (result: ReturnType<typeof generateHomepageJsonLd>) =>
+    result['@graph'] as Array<Record<string, unknown>>;
+
+  it('returns @context and @graph', () => {
+    const result = generateHomepageJsonLd(makeJournal(), 'test-journal', 'en');
+    expect(result['@context']).toBe('https://schema.org');
+    expect(Array.isArray(graph(result))).toBe(true);
+    expect(graph(result)).toHaveLength(3);
+  });
+
+  it('includes Organization for Episciences publisher with stable @id', () => {
+    const [org] = graph(generateHomepageJsonLd(makeJournal(), 'test-journal', 'en'));
+    expect(org['@type']).toBe('Organization');
+    expect(org['@id']).toBe('https://www.episciences.org/#publisher');
+    expect(org['name']).toBe('Episciences.org');
+  });
+
+  it('includes WebSite with language-agnostic @id', () => {
+    const [, website] = graph(generateHomepageJsonLd(makeJournal(), 'test-journal', 'en'));
+    expect(website['@type']).toBe('WebSite');
+    expect(website['@id']).toBe(`${BASE}/#website`);
+    expect(website['url']).toBe(`${BASE}/`);
+    expect(website['name']).toBe('Test Journal');
+  });
+
+  it('WebSite references publisher by @id only', () => {
+    const [, website] = graph(generateHomepageJsonLd(makeJournal(), 'test-journal', 'en'));
+    expect((website['publisher'] as any)['@id']).toBe('https://www.episciences.org/#publisher');
+    expect((website['publisher'] as any)['name']).toBeUndefined();
+  });
+
+  it('includes Periodical with language-agnostic @id', () => {
+    const [,, periodical] = graph(generateHomepageJsonLd(makeJournal(), 'test-journal', 'en'));
+    expect(periodical['@type']).toBe('Periodical');
+    expect(periodical['@id']).toBe(`${BASE}/#periodical`);
+    expect(periodical['name']).toBe('Test Journal');
+  });
+
+  it('includes issn from journal.issn field', () => {
+    const [,, periodical] = graph(
+      generateHomepageJsonLd(makeJournal({ issn: '1234-5678' }), 'test-journal', 'en')
+    );
+    expect(periodical['issn']).toBe('1234-5678');
+  });
+
+  it('falls back to ISSN from settings when journal.issn is absent', () => {
+    const journal = makeJournal({
+      settings: [{ setting: 'ISSN', value: '9876-5432' }],
+    });
+    const [,, periodical] = graph(generateHomepageJsonLd(journal, 'test-journal', 'en'));
+    expect(periodical['issn']).toBe('9876-5432');
+  });
+
+  it('returns issn as array when both issn and eissn are present', () => {
+    const journal = makeJournal({ issn: '1234-5678', eissn: '8765-4321' });
+    const [,, periodical] = graph(generateHomepageJsonLd(journal, 'test-journal', 'en'));
+    expect(Array.isArray(periodical['issn'])).toBe(true);
+    expect(periodical['issn']).toContain('1234-5678');
+    expect(periodical['issn']).toContain('8765-4321');
+  });
+
+  it('omits issn field when neither issn nor eissn are present', () => {
+    const [,, periodical] = graph(generateHomepageJsonLd(makeJournal(), 'test-journal', 'en'));
+    expect(periodical['issn']).toBeUndefined();
+  });
+
+  it('includes alternateName from subtitle when present', () => {
+    const [,, periodical] = graph(
+      generateHomepageJsonLd(makeJournal({ subtitle: 'A Subtitle' }), 'test-journal', 'en')
+    );
+    expect(periodical['alternateName']).toBe('A Subtitle');
+  });
+
+  it('omits alternateName when subtitle is absent', () => {
+    const [,, periodical] = graph(generateHomepageJsonLd(makeJournal(), 'test-journal', 'en'));
+    expect(periodical['alternateName']).toBeUndefined();
+  });
+
+  it('includes lang-aware publishingPrinciples', () => {
+    const [,, periodical] = graph(generateHomepageJsonLd(makeJournal(), 'test-journal', 'fr'));
+    const principles = periodical['publishingPrinciples'] as string[];
+    expect(principles).toContain(`${BASE}/fr/ethical-charter`);
+    expect(principles).toContain(`${BASE}/fr/for-authors`);
+  });
+
+  it('Periodical references publisher by @id only', () => {
+    const [,, periodical] = graph(generateHomepageJsonLd(makeJournal(), 'test-journal', 'en'));
+    expect((periodical['publisher'] as any)['@id']).toBe('https://www.episciences.org/#publisher');
+    expect((periodical['publisher'] as any)['name']).toBeUndefined();
+  });
+});
+
+// --- @id helpers ---
+
+describe('getWebSiteId', () => {
+  it('returns a language-agnostic URI', () => {
+    expect(getWebSiteId('test-journal')).toBe(`${BASE}/#website`);
+  });
+});
+
+describe('getPeriodicalId', () => {
+  it('returns a language-agnostic URI', () => {
+    expect(getPeriodicalId('test-journal')).toBe(`${BASE}/#periodical`);
+  });
+});
+
+describe('getWebPageId', () => {
+  it('includes lang and route', () => {
+    expect(getWebPageId('test-journal', 'en', '/about')).toBe(`${BASE}/en/about#webpage`);
+  });
+
+  it('handles root route without trailing slash in @id', () => {
+    expect(getWebPageId('test-journal', 'en', '/')).toBe(`${BASE}/en#webpage`);
+  });
+
+  it('adds leading slash when missing', () => {
+    expect(getWebPageId('test-journal', 'fr', 'volumes')).toBe(`${BASE}/fr/volumes#webpage`);
+  });
+});
+
+describe('getArticleId', () => {
+  it('includes lang and articleId', () => {
+    expect(getArticleId('test-journal', 'en', '42')).toBe(`${BASE}/en/articles/42#article`);
+  });
+});
+
+// --- generateBreadcrumbJsonLd ---
+
+describe('generateBreadcrumbJsonLd', () => {
+  const parents = [{ path: '/', label: 'Home >' }];
+
+  it('sets @context and @type correctly', () => {
+    const result = generateBreadcrumbJsonLd(parents, 'Volumes', 'en', 'test-journal', '/en/volumes');
+    expect(result['@context']).toBe('https://schema.org');
+    expect(result['@type']).toBe('BreadcrumbList');
+  });
+
+  it('sets @id from pathname', () => {
+    const result = generateBreadcrumbJsonLd(parents, 'Volumes', 'en', 'test-journal', '/en/volumes');
+    expect(result['@id']).toBe(`${BASE}/en/volumes#breadcrumb`);
+  });
+
+  it('omits @id when pathname is null', () => {
+    const result = generateBreadcrumbJsonLd(parents, 'Volumes', 'en', 'test-journal', null);
+    expect(result['@id']).toBeUndefined();
+  });
+
+  it('assigns sequential 1-based positions', () => {
+    const multiParents = [
+      { path: '/', label: 'Home >' },
+      { path: '/volumes', label: 'Volumes >' },
+    ];
+    const result = generateBreadcrumbJsonLd(multiParents, 'Vol. 1', 'en', 'test-journal', '/en/volumes/1');
+    const items = result['itemListElement'] as Array<{ position: number }>;
+    expect(items[0].position).toBe(1);
+    expect(items[1].position).toBe(2);
+    expect(items[2].position).toBe(3);
+  });
+
+  it('positions remain sequential even when # parents are filtered', () => {
+    const withHash = [
+      { path: '/', label: 'Home >' },
+      { path: '#', label: 'Publish >' },
+    ];
+    const result = generateBreadcrumbJsonLd(withHash, 'For Authors', 'en', 'test-journal', '/en/for-authors');
+    const items = result['itemListElement'] as Array<{ position: number; name: string }>;
+    expect(items).toHaveLength(2);
+    expect(items[0].position).toBe(1);
+    expect(items[1].position).toBe(2);
+  });
+
+  it('filters out items with path === "#"', () => {
+    const withHash = [
+      { path: '/', label: 'Home >' },
+      { path: '#', label: 'Publish >' },
+    ];
+    const result = generateBreadcrumbJsonLd(withHash, 'For Authors', 'en', 'test-journal', '/en/for-authors');
+    const items = result['itemListElement'] as Array<{ name: string }>;
+    const names = items.map(i => i.name);
+    expect(names).not.toContain('Publish >');
+    expect(names).not.toContain('Publish');
+  });
+
+  it('strips trailing " >" from parent labels', () => {
+    const result = generateBreadcrumbJsonLd(parents, 'Volumes', 'en', 'test-journal', '/en/volumes');
+    const items = result['itemListElement'] as Array<{ name: string }>;
+    expect(items[0].name).toBe('Home');
+  });
+
+  it('preserves crumbLabel as-is for the last item', () => {
+    const result = generateBreadcrumbJsonLd(parents, 'Volumes', 'en', 'test-journal', '/en/volumes');
+    const items = result['itemListElement'] as Array<{ name: string }>;
+    expect(items[items.length - 1].name).toBe('Volumes');
+  });
+
+  it('builds the last item URL from pathname', () => {
+    const result = generateBreadcrumbJsonLd(parents, 'Volumes', 'en', 'test-journal', '/en/volumes');
+    const items = result['itemListElement'] as Array<{ item?: string }>;
+    expect(items[items.length - 1].item).toBe(`${BASE}/en/volumes`);
+  });
+
+  it('omits item URL for last item when pathname is null', () => {
+    const result = generateBreadcrumbJsonLd(parents, 'Volumes', 'en', 'test-journal', null);
+    const items = result['itemListElement'] as Array<{ item?: string }>;
+    expect(items[items.length - 1].item).toBeUndefined();
+  });
+
+  it('builds parent item URL using getLocalizedPath for relative paths', () => {
+    const result = generateBreadcrumbJsonLd(parents, 'Volumes', 'en', 'test-journal', '/en/volumes');
+    const items = result['itemListElement'] as Array<{ item?: string }>;
+    expect(items[0].item).toBe(`${BASE}/en/`);
+  });
+
+  it('keeps absolute URLs as-is for parent items', () => {
+    const absoluteParents = [{ path: 'https://external.org/home', label: 'External >' }];
+    const result = generateBreadcrumbJsonLd(absoluteParents, 'Page', 'en', 'test-journal', '/en/page');
+    const items = result['itemListElement'] as Array<{ item?: string }>;
+    expect(items[0].item).toBe('https://external.org/home');
+  });
+});
+
+// --- generateScholarlyArticleJsonLd ---
+
+const makeArticle = (overrides: Partial<IArticle> = {}): IArticle => ({
+  id: 42,
+  title: 'A Great Paper',
+  authors: [
+    {
+      fullname: 'Jane Doe',
+      orcid: '0000-0001-2345-6789',
+      institutions: [{ name: 'MIT', rorId: '042nb2s44' }],
+    },
+  ],
+  publicationDate: '2024-03-15',
+  doi: '10.1234/test',
+  repositoryName: 'arXiv',
+  repositoryIdentifier: 'arXiv:2401.00001',
+  ...overrides,
+});
+
+const makeVolume = (overrides: Partial<IVolume> = {}): IVolume => ({
+  id: 1,
+  num: '3',
+  articles: [],
+  downloadLink: '',
+  ...overrides,
+});
+
+describe('generateScholarlyArticleJsonLd', () => {
+  it('sets @context, @type, @id and url correctly', () => {
+    const result = generateScholarlyArticleJsonLd(makeArticle(), 'test-journal', 'en');
+    expect(result['@context']).toBe('https://schema.org');
+    expect(result['@type']).toBe('ScholarlyArticle');
+    expect(result['@id']).toBe(`${BASE}/en/articles/42#article`);
+    expect(result['url']).toBe(`${BASE}/en/articles/42`);
+  });
+
+  it('maps headline from article.title', () => {
+    const result = generateScholarlyArticleJsonLd(makeArticle(), 'test-journal', 'en');
+    expect(result['headline']).toBe('A Great Paper');
+  });
+
+  it('includes string abstract as description', () => {
+    const result = generateScholarlyArticleJsonLd(
+      makeArticle({ abstract: 'Short abstract.' }),
+      'test-journal',
+      'en'
+    );
+    expect(result['description']).toBe('Short abstract.');
+  });
+
+  it('extracts description from multilingual abstract using lang', () => {
+    const result = generateScholarlyArticleJsonLd(
+      makeArticle({ abstract: { en: 'English abstract', fr: 'Résumé français' } as any }),
+      'test-journal',
+      'en'
+    );
+    expect(result['description']).toBe('English abstract');
+  });
+
+  it('falls back to first available abstract when lang is missing', () => {
+    const result = generateScholarlyArticleJsonLd(
+      makeArticle({ abstract: { fr: 'Résumé' } as any }),
+      'test-journal',
+      'en'
+    );
+    expect(result['description']).toBe('Résumé');
+  });
+
+  it('omits description when abstract is absent', () => {
+    const result = generateScholarlyArticleJsonLd(makeArticle({ abstract: undefined }), 'test-journal', 'en');
+    expect(result['description']).toBeUndefined();
+  });
+
+  it('sets datePublished from article.publicationDate', () => {
+    const result = generateScholarlyArticleJsonLd(makeArticle(), 'test-journal', 'en');
+    expect(result['datePublished']).toBe('2024-03-15');
+  });
+
+  it('includes dateModified when present', () => {
+    const result = generateScholarlyArticleJsonLd(
+      makeArticle({ modificationDate: '2024-04-01' }),
+      'test-journal',
+      'en'
+    );
+    expect(result['dateModified']).toBe('2024-04-01');
+  });
+
+  it('omits dateModified when absent', () => {
+    const result = generateScholarlyArticleJsonLd(makeArticle({ modificationDate: undefined }), 'test-journal', 'en');
+    expect(result['dateModified']).toBeUndefined();
+  });
+
+  it('includes dateCreated from submissionDate when present', () => {
+    const result = generateScholarlyArticleJsonLd(
+      makeArticle({ submissionDate: '2023-11-01' }),
+      'test-journal',
+      'en'
+    );
+    expect(result['dateCreated']).toBe('2023-11-01');
+  });
+
+  it('includes license when present', () => {
+    const result = generateScholarlyArticleJsonLd(
+      makeArticle({ license: 'https://creativecommons.org/licenses/by/4.0/' }),
+      'test-journal',
+      'en'
+    );
+    expect(result['license']).toBe('https://creativecommons.org/licenses/by/4.0/');
+  });
+
+  it('maps authors with fullname', () => {
+    const result = generateScholarlyArticleJsonLd(makeArticle(), 'test-journal', 'en');
+    const authors = result['author'] as Array<{ name: string }>;
+    expect(authors[0].name).toBe('Jane Doe');
+  });
+
+  it('prefixes bare ORCID with https://orcid.org/', () => {
+    const result = generateScholarlyArticleJsonLd(makeArticle(), 'test-journal', 'en');
+    const authors = result['author'] as Array<{ sameAs?: string }>;
+    expect(authors[0].sameAs).toBe('https://orcid.org/0000-0001-2345-6789');
+  });
+
+  it('keeps full ORCID URL as-is', () => {
+    const result = generateScholarlyArticleJsonLd(
+      makeArticle({ authors: [{ fullname: 'A', orcid: 'https://orcid.org/0000-0001-2345-6789' }] }),
+      'test-journal',
+      'en'
+    );
+    const authors = result['author'] as Array<{ sameAs?: string }>;
+    expect(authors[0].sameAs).toBe('https://orcid.org/0000-0001-2345-6789');
+  });
+
+  it('omits sameAs on author when orcid is absent', () => {
+    const result = generateScholarlyArticleJsonLd(
+      makeArticle({ authors: [{ fullname: 'B' }] }),
+      'test-journal',
+      'en'
+    );
+    const authors = result['author'] as Array<{ sameAs?: string }>;
+    expect(authors[0].sameAs).toBeUndefined();
+  });
+
+  it('maps institution with prefixed ROR id', () => {
+    const result = generateScholarlyArticleJsonLd(makeArticle(), 'test-journal', 'en');
+    const authors = result['author'] as Array<{ affiliation?: { sameAs?: string } }>;
+    expect(authors[0].affiliation?.sameAs).toBe('https://ror.org/042nb2s44');
+  });
+
+  it('uses array affiliation when author has multiple institutions', () => {
+    const result = generateScholarlyArticleJsonLd(
+      makeArticle({
+        authors: [{
+          fullname: 'C',
+          institutions: [{ name: 'MIT' }, { name: 'Harvard' }],
+        }],
+      }),
+      'test-journal',
+      'en'
+    );
+    const authors = result['author'] as Array<{ affiliation?: unknown }>;
+    expect(Array.isArray(authors[0].affiliation)).toBe(true);
+  });
+
+  it('uses single object affiliation when author has one institution', () => {
+    const result = generateScholarlyArticleJsonLd(makeArticle(), 'test-journal', 'en');
+    const authors = result['author'] as Array<{ affiliation?: unknown }>;
+    expect(Array.isArray(authors[0].affiliation)).toBe(false);
+    expect(typeof authors[0].affiliation).toBe('object');
+  });
+
+  it('prefixes doi with https://doi.org/', () => {
+    const result = generateScholarlyArticleJsonLd(makeArticle(), 'test-journal', 'en');
+    const sameAs = result['sameAs'] as string[];
+    expect(sameAs).toContain('https://doi.org/10.1234/test');
+  });
+
+  it('keeps full DOI URL as-is', () => {
+    const result = generateScholarlyArticleJsonLd(
+      makeArticle({ doi: 'https://doi.org/10.1234/test' }),
+      'test-journal',
+      'en'
+    );
+    const sameAs = result['sameAs'] as string[];
+    expect(sameAs).toContain('https://doi.org/10.1234/test');
+    expect(sameAs.filter(s => s.startsWith('https://doi.org/')).length).toBe(1);
+  });
+
+  it('includes docLink in sameAs', () => {
+    const result = generateScholarlyArticleJsonLd(
+      makeArticle({ docLink: 'https://arxiv.org/abs/2401.00001' }),
+      'test-journal',
+      'en'
+    );
+    const sameAs = result['sameAs'] as string[];
+    expect(sameAs).toContain('https://arxiv.org/abs/2401.00001');
+  });
+
+  it('omits sameAs when doi and docLink are both absent', () => {
+    const result = generateScholarlyArticleJsonLd(
+      makeArticle({ doi: '', docLink: undefined }),
+      'test-journal',
+      'en'
+    );
+    expect(result['sameAs']).toBeUndefined();
+  });
+
+  it('sets isPartOf to Periodical @id when no volume', () => {
+    const result = generateScholarlyArticleJsonLd(makeArticle(), 'test-journal', 'en');
+    expect((result['isPartOf'] as any)['@id']).toBe(`${BASE}/#periodical`);
+  });
+
+  it('wraps isPartOf in PublicationVolume when volume is provided', () => {
+    const result = generateScholarlyArticleJsonLd(makeArticle(), 'test-journal', 'en', makeVolume());
+    const isPartOf = result['isPartOf'] as any;
+    expect(isPartOf['@type']).toBe('PublicationVolume');
+    expect(isPartOf['volumeNumber']).toBe('3');
+    expect(isPartOf['isPartOf']['@id']).toBe(`${BASE}/#periodical`);
+  });
+
+  it('includes funders when present', () => {
+    const result = generateScholarlyArticleJsonLd(
+      makeArticle({ fundings: ['ANR', 'ERC'] }),
+      'test-journal',
+      'en'
+    );
+    const funder = result['funder'] as Array<{ name: string }>;
+    expect(funder).toHaveLength(2);
+    expect(funder[0].name).toBe('ANR');
+    expect(funder[1].name).toBe('ERC');
+  });
+
+  it('omits funder when fundings is absent', () => {
+    const result = generateScholarlyArticleJsonLd(makeArticle({ fundings: undefined }), 'test-journal', 'en');
+    expect(result['funder']).toBeUndefined();
+  });
+
+  it('sets publisher to Episciences.org with stable @id', () => {
+    const result = generateScholarlyArticleJsonLd(makeArticle(), 'test-journal', 'en');
+    const publisher = result['publisher'] as any;
+    expect(publisher['@type']).toBe('Organization');
+    expect(publisher['@id']).toBe('https://www.episciences.org/#publisher');
+    expect(publisher['name']).toBe('Episciences.org');
+  });
+
+  it('handles article with no authors', () => {
+    const result = generateScholarlyArticleJsonLd(makeArticle({ authors: [] }), 'test-journal', 'en');
+    expect(result['author']).toEqual([]);
+  });
+});
+
+// --- generateWebPageJsonLd ---
+
+describe('generateWebPageJsonLd', () => {
+  it('sets @context, @type, @id and url for WebPage', () => {
+    const result = generateWebPageJsonLd('WebPage', 'test-journal', 'en', '/for-authors');
+    expect(result['@context']).toBe('https://schema.org');
+    expect(result['@type']).toBe('WebPage');
+    expect(result['@id']).toBe(`${BASE}/en/for-authors#webpage`);
+    expect(result['url']).toBe(`${BASE}/en/for-authors`);
+  });
+
+  it('uses AboutPage type when specified', () => {
+    const result = generateWebPageJsonLd('AboutPage', 'test-journal', 'en', '/about');
+    expect(result['@type']).toBe('AboutPage');
+  });
+
+  it('sets inLanguage from lang param', () => {
+    const result = generateWebPageJsonLd('WebPage', 'test-journal', 'fr', '/credits');
+    expect(result['inLanguage']).toBe('fr');
+  });
+
+  it('references WebSite via isPartOf @id', () => {
+    const result = generateWebPageJsonLd('WebPage', 'test-journal', 'en', '/boards');
+    expect((result['isPartOf'] as any)['@id']).toBe(`${BASE}/#website`);
+  });
+
+  it('includes name when provided', () => {
+    const result = generateWebPageJsonLd('WebPage', 'test-journal', 'en', '/indexing', {
+      name: 'Indexing',
+    });
+    expect(result['name']).toBe('Indexing');
+  });
+
+  it('omits name when not provided', () => {
+    const result = generateWebPageJsonLd('WebPage', 'test-journal', 'en', '/indexing');
+    expect(result['name']).toBeUndefined();
+  });
+
+  it('includes lastReviewed when provided', () => {
+    const result = generateWebPageJsonLd('AboutPage', 'test-journal', 'en', '/about', {
+      lastReviewed: '2025-01-15',
+    });
+    expect(result['lastReviewed']).toBe('2025-01-15');
+  });
+
+  it('omits lastReviewed when not provided', () => {
+    const result = generateWebPageJsonLd('AboutPage', 'test-journal', 'en', '/about');
+    expect(result['lastReviewed']).toBeUndefined();
+  });
+
+  it('omits lastReviewed when value is undefined', () => {
+    const result = generateWebPageJsonLd('AboutPage', 'test-journal', 'en', '/about', {
+      lastReviewed: undefined,
+    });
+    expect(result['lastReviewed']).toBeUndefined();
+  });
+
+  it('adds leading slash to route when missing', () => {
+    const result = generateWebPageJsonLd('WebPage', 'test-journal', 'en', 'statistics');
+    expect(result['url']).toBe(`${BASE}/en/statistics`);
+  });
+});
+
+// --- generateCollectionPageJsonLd ---
+
+describe('generateCollectionPageJsonLd', () => {
+  it('sets @context, @type, @id and url', () => {
+    const result = generateCollectionPageJsonLd('test-journal', 'en', '/volumes');
+    expect(result['@context']).toBe('https://schema.org');
+    expect(result['@type']).toBe('CollectionPage');
+    expect(result['@id']).toBe(`${BASE}/en/volumes#webpage`);
+    expect(result['url']).toBe(`${BASE}/en/volumes`);
+  });
+
+  it('sets inLanguage from lang param', () => {
+    const result = generateCollectionPageJsonLd('test-journal', 'fr', '/articles');
+    expect(result['inLanguage']).toBe('fr');
+  });
+
+  it('references WebSite via isPartOf @id', () => {
+    const result = generateCollectionPageJsonLd('test-journal', 'en', '/volumes');
+    expect((result['isPartOf'] as any)['@id']).toBe(`${BASE}/#website`);
+  });
+
+  it('includes name when provided', () => {
+    const result = generateCollectionPageJsonLd('test-journal', 'en', '/volumes', {
+      name: 'Volumes',
+    });
+    expect(result['name']).toBe('Volumes');
+  });
+
+  it('omits name when not provided', () => {
+    const result = generateCollectionPageJsonLd('test-journal', 'en', '/volumes');
+    expect(result['name']).toBeUndefined();
+  });
+
+  it('includes mainEntity ItemList with numberOfItems when provided', () => {
+    const result = generateCollectionPageJsonLd('test-journal', 'en', '/volumes', {
+      numberOfItems: 42,
+    });
+    const mainEntity = result['mainEntity'] as any;
+    expect(mainEntity['@type']).toBe('ItemList');
+    expect(mainEntity['numberOfItems']).toBe(42);
+  });
+
+  it('omits mainEntity when numberOfItems is not provided', () => {
+    const result = generateCollectionPageJsonLd('test-journal', 'en', '/volumes');
+    expect(result['mainEntity']).toBeUndefined();
+  });
+
+  it('includes mainEntity when numberOfItems is 0', () => {
+    const result = generateCollectionPageJsonLd('test-journal', 'en', '/articles', {
+      numberOfItems: 0,
+    });
+    const mainEntity = result['mainEntity'] as any;
+    expect(mainEntity).toBeDefined();
+    expect(mainEntity['numberOfItems']).toBe(0);
+  });
+
+  it('adds leading slash to route when missing', () => {
+    const result = generateCollectionPageJsonLd('test-journal', 'en', 'articles');
+    expect(result['url']).toBe(`${BASE}/en/articles`);
+  });
+});

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -1,0 +1,265 @@
+import type { IArticle, IArticleAbstracts, IArticleAuthor } from '@/types/article';
+import type { IJournal } from '@/types/journal';
+import type { IVolume } from '@/types/volume';
+import { getJournalBaseUrl } from './signposting';
+import { getLocalizedPath } from './language-utils';
+
+export type SchemaOrgEntity = {
+  '@type': string | string[];
+  '@id'?: string;
+  [key: string]: unknown;
+};
+
+export type SchemaOrgThing =
+  | ({ '@context': 'https://schema.org'; '@graph': SchemaOrgEntity[] })
+  | ({ '@context': 'https://schema.org' } & SchemaOrgEntity);
+
+// --- Stable @id helpers (language-agnostic for journal-level entities) ---
+
+export function getWebSiteId(journalId: string): string {
+  return `${getJournalBaseUrl(journalId)}/#website`;
+}
+
+export function getPeriodicalId(journalId: string): string {
+  return `${getJournalBaseUrl(journalId)}/#periodical`;
+}
+
+// WebPage @id includes lang since it is a localised resource
+export function getWebPageId(journalId: string, lang: string, route: string): string {
+  const cleanRoute = route === '/' ? '' : route.startsWith('/') ? route : `/${route}`;
+  return `${getJournalBaseUrl(journalId)}/${lang}${cleanRoute}#webpage`;
+}
+
+export function getArticleId(journalId: string, lang: string, articleId: string): string {
+  return `${getJournalBaseUrl(journalId)}/${lang}/articles/${articleId}#article`;
+}
+
+// --- Homepage (@graph: Organization + WebSite + Periodical) ---
+
+const EPISCIENCES_PUBLISHER: SchemaOrgEntity = {
+  '@type': 'Organization',
+  '@id': 'https://www.episciences.org/#publisher',
+  name: 'Episciences.org',
+  url: 'https://www.episciences.org',
+};
+
+function getIssnList(journal: IJournal): string[] {
+  const issn =
+    journal.issn || journal.settings?.find(s => s.setting === 'ISSN')?.value;
+  const eissn =
+    journal.eissn || journal.settings?.find(s => s.setting === 'EISSN')?.value;
+  return [issn, eissn].filter((v): v is string => Boolean(v));
+}
+
+export function generateHomepageJsonLd(
+  journal: IJournal,
+  journalId: string,
+  lang: string
+): SchemaOrgThing {
+  const baseUrl = getJournalBaseUrl(journalId);
+  const journalUrl = `${baseUrl}/`;
+  const issnList = getIssnList(journal);
+  const publisherRef = { '@id': 'https://www.episciences.org/#publisher' };
+
+  const periodical: SchemaOrgEntity = {
+    '@type': 'Periodical',
+    '@id': getPeriodicalId(journalId),
+    name: journal.name,
+    ...(journal.subtitle && { alternateName: journal.subtitle }),
+    url: journalUrl,
+    ...(issnList.length === 1 && { issn: issnList[0] }),
+    ...(issnList.length > 1 && { issn: issnList }),
+    publisher: publisherRef,
+    publishingPrinciples: [
+      `${baseUrl}/${lang}/ethical-charter`,
+      `${baseUrl}/${lang}/for-authors`,
+    ],
+  };
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      EPISCIENCES_PUBLISHER,
+      {
+        '@type': 'WebSite',
+        '@id': getWebSiteId(journalId),
+        url: journalUrl,
+        name: journal.name,
+        publisher: publisherRef,
+      },
+      periodical,
+    ],
+  };
+}
+
+// --- ScholarlyArticle ---
+
+function extractAbstract(abstract: string | IArticleAbstracts | undefined, lang: string): string {
+  if (!abstract) return '';
+  if (typeof abstract === 'string') return abstract;
+  return (abstract as Record<string, string>)[lang] || Object.values(abstract)[0] || '';
+}
+
+function toAbsoluteUrl(value: string, prefix: string): string {
+  return value.startsWith('http') ? value : `${prefix}${value}`;
+}
+
+function buildAuthorJsonLd(author: IArticleAuthor): SchemaOrgEntity {
+  const person: SchemaOrgEntity = { '@type': 'Person', name: author.fullname };
+
+  if (author.orcid) {
+    person.sameAs = toAbsoluteUrl(author.orcid, 'https://orcid.org/');
+  }
+
+  if (author.institutions && author.institutions.length > 0) {
+    const affiliations = author.institutions.map(inst => ({
+      '@type': 'Organization',
+      name: inst.name,
+      ...(inst.rorId && { sameAs: toAbsoluteUrl(inst.rorId, 'https://ror.org/') }),
+    }));
+    person.affiliation = affiliations.length === 1 ? affiliations[0] : affiliations;
+  }
+
+  return person;
+}
+
+export function generateScholarlyArticleJsonLd(
+  article: IArticle,
+  journalId: string,
+  lang: string,
+  volume?: IVolume | null
+): SchemaOrgThing {
+  const baseUrl = getJournalBaseUrl(journalId);
+  const articleUrl = `${baseUrl}/${lang}/articles/${article.id}`;
+  const abstractStr = extractAbstract(article.abstract, lang);
+
+  const periodicalRef = { '@id': getPeriodicalId(journalId) };
+  const isPartOf = volume
+    ? { '@type': 'PublicationVolume', volumeNumber: volume.num, isPartOf: periodicalRef }
+    : periodicalRef;
+
+  const sameAs = [
+    article.doi ? toAbsoluteUrl(article.doi, 'https://doi.org/') : null,
+    article.docLink || null,
+  ].filter((v): v is string => v !== null && v !== '');
+
+  const funders = (article.fundings ?? []).map(name => ({ '@type': 'Organization', name }));
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ScholarlyArticle',
+    '@id': getArticleId(journalId, lang, String(article.id)),
+    url: articleUrl,
+    headline: article.title,
+    ...(abstractStr && { description: abstractStr }),
+    inLanguage: lang,
+    datePublished: article.publicationDate,
+    ...(article.modificationDate && { dateModified: article.modificationDate }),
+    ...(article.submissionDate && { dateCreated: article.submissionDate }),
+    ...(article.license && { license: article.license }),
+    author: article.authors.map(buildAuthorJsonLd),
+    ...(funders.length > 0 && { funder: funders }),
+    isPartOf,
+    ...(sameAs.length > 0 && { sameAs }),
+    publisher: {
+      '@type': 'Organization',
+      '@id': 'https://www.episciences.org/#publisher',
+      name: 'Episciences.org',
+      url: 'https://www.episciences.org',
+    },
+  };
+}
+
+// --- WebPage / AboutPage ---
+
+export function generateWebPageJsonLd(
+  type: 'AboutPage' | 'WebPage',
+  journalId: string,
+  lang: string,
+  route: string,
+  options?: { name?: string; lastReviewed?: string }
+): SchemaOrgThing {
+  const baseUrl = getJournalBaseUrl(journalId);
+  const cleanRoute = route.startsWith('/') ? route : `/${route}`;
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': type,
+    '@id': getWebPageId(journalId, lang, route),
+    url: `${baseUrl}/${lang}${cleanRoute}`,
+    inLanguage: lang,
+    ...(options?.name && { name: options.name }),
+    ...(options?.lastReviewed && { lastReviewed: options.lastReviewed }),
+    isPartOf: { '@id': getWebSiteId(journalId) },
+  };
+}
+
+// --- CollectionPage ---
+
+export function generateCollectionPageJsonLd(
+  journalId: string,
+  lang: string,
+  route: string,
+  options?: { name?: string; numberOfItems?: number }
+): SchemaOrgThing {
+  const baseUrl = getJournalBaseUrl(journalId);
+  const cleanRoute = route.startsWith('/') ? route : `/${route}`;
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    '@id': getWebPageId(journalId, lang, route),
+    url: `${baseUrl}/${lang}${cleanRoute}`,
+    inLanguage: lang,
+    ...(options?.name && { name: options.name }),
+    isPartOf: { '@id': getWebSiteId(journalId) },
+    ...(options?.numberOfItems !== undefined && {
+      mainEntity: { '@type': 'ItemList', numberOfItems: options.numberOfItems },
+    }),
+  };
+}
+
+// --- BreadcrumbList ---
+
+export interface BreadcrumbParent {
+  path: string;
+  label: string;
+}
+
+export function generateBreadcrumbJsonLd(
+  parents: BreadcrumbParent[],
+  crumbLabel: string,
+  lang: string,
+  journalId: string,
+  pathname: string | null
+): SchemaOrgThing {
+  const baseUrl = getJournalBaseUrl(journalId);
+
+  const parentItems = parents
+    .filter(parent => parent.path !== '#')
+    .map(parent => ({
+      '@type': 'ListItem' as const,
+      name: parent.label.replace(/\s*>\s*$/, '').trim(),
+      item: parent.path.startsWith('http')
+        ? parent.path
+        : `${baseUrl}${getLocalizedPath(parent.path, lang)}`,
+    }));
+
+  const currentItem = {
+    '@type': 'ListItem' as const,
+    name: crumbLabel,
+    ...(pathname !== null && { item: `${baseUrl}${pathname}` }),
+  };
+
+  const itemListElement = [...parentItems, currentItem].map((item, idx) => ({
+    ...item,
+    position: idx + 1,
+  }));
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    ...(pathname !== null && { '@id': `${baseUrl}${pathname}#breadcrumb` }),
+    itemListElement,
+  };
+}


### PR DESCRIPTION
## Summary

Inject Schema.org JSON-LD structured data across the entire multi-tenant application to improve SEO and enable rich results in Google Search Console.

### Architecture

- **`src/utils/schema.ts`** — central module with typed `@id` helpers and five generator functions; decoupled from any React component
- **`src/components/Meta/JsonLd.tsx`** — pure leaf renderer with triple XSS escaping (`<→<`, `>→>`, `&→&`) via `dangerouslySetInnerHTML`; the standard Next.js pattern for JSON-LD

### Schema types emitted per page

| Page | Schema type | Notable properties |
|------|-------------|-------------------|
| Homepage | `@graph`: Organization + WebSite + Periodical | ISSN/EISSN, publishingPrinciples |
| `/articles/[id]` | `ScholarlyArticle` | authors (ORCID), affiliations (ROR), DOI, funders, license, volume |
| `/about` | `AboutPage` | `lastReviewed` from API |
| `/volumes` | `CollectionPage` | `mainEntity.numberOfItems` |
| `/articles` | `CollectionPage` | `mainEntity.numberOfItems` |
| `/boards`, `/for-authors`, `/ethical-charter`, `/for-reviewers`, `/acknowledgements`, `/indexing`, `/credits`, `/statistics`, `/accessibility`, `/for-conference-organisers` | `WebPage` | `name`, `inLanguage`, `isPartOf` |
| All pages | `BreadcrumbList` | sequential positions, `@id` from `usePathname` |

### Key design decisions

- **Language-agnostic `@id`** for journal-level entities (`/#website`, `/#periodical`) — stable across languages
- **Language-specific `@id`** for page-level entities (`/{lang}/{route}#webpage`) — correct for localised content
- **Breadcrumb bug fix**: positions were non-sequential when `#` parents were filtered; now assigned *after* filtering
- **No extra HTTP call on homepage**: `getJournalByCode()` is deduplicated by Next.js fetch across `HeaderServer` and `page.tsx` in the same render tree
- **Periodical on article pages**: referenced by `@id` only (entity defined on homepage) to avoid duplication

## Test plan

- [ ] 2277 tests passing (`npm run test`)
- [ ] 81 unit tests for `schema.ts` generators and `@id` helpers
- [ ] 7 unit tests for `JsonLd.tsx` (serialization + XSS escaping)
- [ ] 9 new JSON-LD tests in `Breadcrumb.test.tsx`
- [ ] Validate output with [Google Rich Results Test](https://search.google.com/test/rich-results) on a deployed preview
- [ ] Validate with [Schema.org Validator](https://validator.schema.org/) for BreadcrumbList and ScholarlyArticle