### PR TITLE
fix: security & accessibility audit remediation

### DIFF
--- a/deployment/production/nginx-episciences.conf.template
+++ b/deployment/production/nginx-episciences.conf.template
@@ -104,6 +104,13 @@ server {
         log_not_found off;
     }
 
+    # Block direct access to internal multi-tenant paths: /sites/<journal>/<lang>/...
+    # is an internal rewrite target of the Next.js middleware. Reaching it directly
+    # would bypass journal detection/validation and expose cross-tenant content.
+    location ^~ /sites/ {
+        return 404;
+    }
+
     # -----------------------------------------------------------------------
     # PROXY TO NEXT.JS (systemd service on 127.0.0.1:3000)
     # -----------------------------------------------------------------------

--- a/docker/nginx-config/episciences.conf.template
+++ b/docker/nginx-config/episciences.conf.template
@@ -78,6 +78,13 @@ server {
         log_not_found off;
     }
 
+    # Block direct access to internal multi-tenant paths: /sites/<journal>/<lang>/...
+    # is an internal rewrite target of the Next.js middleware. Reaching it directly
+    # would bypass journal detection/validation and expose cross-tenant content.
+    location ^~ /sites/ {
+        return 404;
+    }
+
     # ==============================================================================
     # PROXY TO NEXT.JS
     # ==============================================================================

--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,9 @@ const { branch: GIT_BRANCH, commit: GIT_COMMIT } = getGitInfo();
 const nextConfig = {
   reactStrictMode: true,
 
+  // Do not advertise the framework in response headers
+  poweredByHeader: false,
+
   env: {
     NEXT_GIT_BRANCH: GIT_BRANCH,
     NEXT_GIT_COMMIT: GIT_COMMIT,
@@ -91,17 +94,17 @@ const nextConfig = {
   },
 
   async rewrites() {
-    // Default to preprod if API_PROXY_TARGET or NEXT_PUBLIC_API_ROOT_ENDPOINT is not set in .env
-    const apiTarget =
-      process.env.API_PROXY_TARGET ||
-      process.env.NEXT_PUBLIC_API_ROOT_ENDPOINT ||
-      'https://api-preprod.episciences.org/api';
-    console.log(`[Next.js] Proxying /api-proxy to: ${apiTarget}`);
-
+    // Local-dev CORS escape hatch only (see docs/LOCAL_TESTING_GUIDE.md).
+    // Opt-in via API_PROXY_TARGET: never enabled by default, as this is an
+    // unauthenticated, un-rate-limited pass-through to the target API.
+    if (!process.env.API_PROXY_TARGET) {
+      return [];
+    }
+    console.log(`[Next.js] Proxying /api-proxy to: ${process.env.API_PROXY_TARGET}`);
     return [
       {
         source: '/api-proxy/:path*',
-        destination: `${apiTarget}/:path*`,
+        destination: `${process.env.API_PROXY_TARGET}/:path*`,
       },
     ];
   },

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -187,6 +187,13 @@
       "download": "Download",
       "loading": "Loading PDF...",
       "error": "Failed to load PDF"
+    },
+    "pagination": {
+      "previous": "Previous page",
+      "previousDisabled": "Previous page (disabled)",
+      "next": "Next page",
+      "nextDisabled": "Next page (disabled)",
+      "page": "Page {{number}}"
     }
   },
   "pages": {

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -187,6 +187,13 @@
       "download": "Descargar",
       "loading": "Cargando PDF...",
       "error": "Error al cargar el PDF"
+    },
+    "pagination": {
+      "previous": "Página anterior",
+      "previousDisabled": "Página anterior (desactivado)",
+      "next": "Página siguiente",
+      "nextDisabled": "Página siguiente (desactivado)",
+      "page": "Página {{number}}"
     }
   },
   "pages": {

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -194,6 +194,13 @@
       "download": "Télécharger",
       "loading": "Chargement du PDF...",
       "error": "Erreur de chargement du PDF"
+    },
+    "pagination": {
+      "previous": "Page précédente",
+      "previousDisabled": "Page précédente (désactivé)",
+      "next": "Page suivante",
+      "nextDisabled": "Page suivante (désactivé)",
+      "page": "Page {{number}}"
     }
   },
   "pages": {

--- a/src/app/api/pdf-proxy/__tests__/route.test.ts
+++ b/src/app/api/pdf-proxy/__tests__/route.test.ts
@@ -6,6 +6,11 @@ vi.mock('@/utils/validation', () => ({
     const first = raw?.split(',')[0]?.trim() ?? '';
     return /^[\d.:a-fA-F]+$/.test(first) ? first : 'unknown';
   }),
+  getClientIp: vi.fn((headers: Headers) => {
+    const raw = headers.get('x-real-ip') ?? headers.get('x-forwarded-for');
+    const first = raw?.split(',')[0]?.trim() ?? '';
+    return /^[\d.:a-fA-F]+$/.test(first) ? first : 'unknown';
+  }),
   sanitizeForLog: vi.fn((value: string | null | undefined) => String(value ?? '').slice(0, 200)),
 }));
 

--- a/src/app/api/pdf-proxy/route.ts
+++ b/src/app/api/pdf-proxy/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { sanitizeIp, sanitizeForLog } from '@/utils/validation';
+import { getClientIp, sanitizeForLog } from '@/utils/validation';
 import { isAllowedPdfDomain } from '@/utils/pdf';
 import { logger } from '@/lib/logger';
 
@@ -50,7 +50,7 @@ function checkRateLimit(ip: string): boolean {
  */
 export async function GET(request: NextRequest) {
   // Get client IP
-  const ip = sanitizeIp(request.headers.get('x-forwarded-for') ?? request.headers.get('x-real-ip'));
+  const ip = getClientIp(request.headers);
 
   // Check rate limit
   if (!checkRateLimit(ip)) {

--- a/src/app/api/proxy/[...path]/__tests__/route.test.ts
+++ b/src/app/api/proxy/[...path]/__tests__/route.test.ts
@@ -11,6 +11,11 @@ vi.mock('@/utils/validation', () => ({
     const first = raw?.split(',')[0]?.trim() ?? '';
     return /^[\d.:a-fA-F]+$/.test(first) ? first : 'unknown';
   }),
+  getClientIp: vi.fn((headers: Headers) => {
+    const raw = headers.get('x-real-ip') ?? headers.get('x-forwarded-for');
+    const first = raw?.split(',')[0]?.trim() ?? '';
+    return /^[\d.:a-fA-F]+$/.test(first) ? first : 'unknown';
+  }),
 }));
 
 function makeGetRequest(path: string, searchParams = ''): NextRequest {
@@ -129,6 +134,26 @@ describe('GET /api/proxy/[...path]', () => {
         expect.stringContaining('api.transformations.test/papers/42'),
         expect.any(Object)
       );
+    });
+
+    it('passes an abort signal to the upstream fetch (timeout protection)', async () => {
+      const { GET } = await import('../route');
+      const context = { params: Promise.resolve({ path: ['papers', '42'] }) };
+      await GET(makeGetRequest('papers/42', '?rvcode=transformations'), context);
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+    });
+
+    it('returns 504 when the upstream request times out', async () => {
+      global.fetch = vi
+        .fn()
+        .mockRejectedValue(new DOMException('The operation timed out', 'TimeoutError'));
+      const { GET } = await import('../route');
+      const context = { params: Promise.resolve({ path: ['papers', '42'] }) };
+      const res = await GET(makeGetRequest('papers/42', '?rvcode=transformations'), context);
+      expect(res.status).toBe(504);
     });
   });
 });

--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getJournalApiUrl } from '@/utils/env-loader';
-import { isValidJournalId, sanitizeIp } from '@/utils/validation';
+import { isValidJournalId, getClientIp } from '@/utils/validation';
 import { logger } from '@/lib/logger';
 
 /**
@@ -18,6 +18,7 @@ import { logger } from '@/lib/logger';
 const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
 const RATE_LIMIT = 60;
 const RATE_WINDOW = 60000; // 1 minute
+const UPSTREAM_TIMEOUT = 15000; // 15 seconds — a slow backend must not pin connections open
 
 // Cleanup expired entries every 5 minutes to prevent memory leak
 setInterval(
@@ -50,9 +51,7 @@ function checkRateLimit(ip: string): boolean {
 }
 
 export async function GET(request: NextRequest, context: { params: Promise<{ path: string[] }> }) {
-  const clientIp = sanitizeIp(
-    request.headers.get('x-forwarded-for') ?? request.headers.get('x-real-ip')
-  );
+  const clientIp = getClientIp(request.headers);
 
   if (!checkRateLimit(clientIp)) {
     return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
@@ -98,6 +97,7 @@ export async function GET(request: NextRequest, context: { params: Promise<{ pat
         Accept: request.headers.get('Accept') || 'application/ld+json',
         'Content-Type': 'application/json',
       },
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT),
     });
 
     const data = await response.text();
@@ -110,15 +110,16 @@ export async function GET(request: NextRequest, context: { params: Promise<{ pat
       },
     });
   } catch (error) {
+    if (error instanceof Error && error.name === 'TimeoutError') {
+      return NextResponse.json({ error: 'Upstream timeout' }, { status: 504 });
+    }
     logger.error(`[API Proxy] Error proxying to ${targetUrl}:`, error);
     return NextResponse.json({ error: 'Failed to proxy request' }, { status: 502 });
   }
 }
 
 export async function POST(request: NextRequest, context: { params: Promise<{ path: string[] }> }) {
-  const clientIp = sanitizeIp(
-    request.headers.get('x-forwarded-for') ?? request.headers.get('x-real-ip')
-  );
+  const clientIp = getClientIp(request.headers);
 
   if (!checkRateLimit(clientIp)) {
     return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
@@ -160,6 +161,7 @@ export async function POST(request: NextRequest, context: { params: Promise<{ pa
         'Content-Type': request.headers.get('Content-Type') || 'application/json',
       },
       body,
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT),
     });
 
     const data = await response.text();
@@ -171,6 +173,9 @@ export async function POST(request: NextRequest, context: { params: Promise<{ pa
       },
     });
   } catch (error) {
+    if (error instanceof Error && error.name === 'TimeoutError') {
+      return NextResponse.json({ error: 'Upstream timeout' }, { status: 504 });
+    }
     logger.error(`[API Proxy] Error proxying POST to ${targetUrl}:`, error);
     return NextResponse.json({ error: 'Failed to proxy request' }, { status: 502 });
   }

--- a/src/app/api/revalidate/__tests__/route.test.ts
+++ b/src/app/api/revalidate/__tests__/route.test.ts
@@ -13,6 +13,11 @@ vi.mock('@/utils/validation', () => ({
     const first = raw?.split(',')[0]?.trim() ?? '';
     return /^[\d.:a-fA-F]+$/.test(first) ? first : 'unknown';
   }),
+  getClientIp: vi.fn((headers: Headers) => {
+    const raw = headers.get('x-real-ip') ?? headers.get('x-forwarded-for');
+    const first = raw?.split(',')[0]?.trim() ?? '';
+    return /^[\d.:a-fA-F]+$/.test(first) ? first : 'unknown';
+  }),
   sanitizeForLog: vi.fn((value: string | null | undefined) => String(value ?? '').slice(0, 200)),
 }));
 
@@ -151,6 +156,25 @@ describe('POST /api/revalidate', () => {
       const { POST } = await import('../route');
       const res = await POST(makeRequest({ tag: 'pages' }, SECRET, '127.0.0.1'));
       expect(res.status).toBe(200);
+    });
+
+    it('returns 403 when x-forwarded-for spoofs an allowed IP but x-real-ip differs', async () => {
+      process.env.ALLOWED_IPS = '10.0.0.1';
+      const { POST } = await import('../route');
+      const req = new NextRequest('http://localhost/api/revalidate', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-episciences-token': SECRET,
+          // Attacker-supplied value: nginx would append the real IP after it
+          'x-forwarded-for': '10.0.0.1, 192.168.1.99',
+          // Trusted value set by nginx from the socket address
+          'x-real-ip': '192.168.1.99',
+        },
+        body: JSON.stringify({ tag: 'pages' }),
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(403);
     });
   });
 

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,7 +1,7 @@
 import { revalidateTag, revalidatePath } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 import crypto from 'crypto';
-import { sanitizeIp, sanitizeForLog } from '@/utils/validation';
+import { getClientIp, sanitizeForLog } from '@/utils/validation';
 import { logger } from '@/lib/logger';
 
 const log = logger.child({ service: 'revalidate-api' });
@@ -112,9 +112,7 @@ export async function POST(request: NextRequest) {
     const allowedIps = process.env.ALLOWED_IPS
       ? process.env.ALLOWED_IPS.split(',').map(ip => ip.trim())
       : [];
-    const clientIp = sanitizeIp(
-      request.headers.get('x-forwarded-for') ?? request.headers.get('x-real-ip')
-    );
+    const clientIp = getClientIp(request.headers);
 
     if (allowedIps.length > 0 && !allowedIps.includes(clientIp)) {
       log.warn(`[Revalidate API] Blocked unauthorized IP: ${clientIp}`);

--- a/src/app/sites/[journalId]/[lang]/articles/[id]/download/route.ts
+++ b/src/app/sites/[journalId]/[lang]/articles/[id]/download/route.ts
@@ -14,6 +14,10 @@ export async function GET(
     return new NextResponse('Invalid journal', { status: 400 });
   }
 
+  if (!/^\d+$/.test(id)) {
+    return new NextResponse('Invalid article id', { status: 400 });
+  }
+
   const article = await fetchArticle(id, journalId);
 
   if (!article?.pdfLink) {

--- a/src/app/sites/[journalId]/[lang]/articles/[id]/preview/route.ts
+++ b/src/app/sites/[journalId]/[lang]/articles/[id]/preview/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { fetchArticle } from '@/services/article';
 import { isAllowedPdfDomain } from '@/utils/pdf';
-import { isValidJournalId } from '@/utils/validation';
+import { isValidJournalId, sanitizeForLog } from '@/utils/validation';
 import { AvailableLanguage } from '@/utils/i18n';
 import { logger } from '@/lib/logger';
 
@@ -25,6 +25,11 @@ export async function GET(
   if (!isValidJournalId(journalId)) {
     logger.warn(`[preview] ❌ Invalid journal ID format: ${journalId}`);
     return new NextResponse('Invalid journal', { status: 400, headers: errorHeaders });
+  }
+
+  if (!/^\d+$/.test(id)) {
+    logger.warn(`[preview] ❌ Invalid article id format: ${sanitizeForLog(id)}`);
+    return new NextResponse('Invalid article id', { status: 400, headers: errorHeaders });
   }
 
   const article = await fetchArticle(id, journalId);

--- a/src/app/sites/[journalId]/[lang]/layout.tsx
+++ b/src/app/sites/[journalId]/[lang]/layout.tsx
@@ -69,7 +69,7 @@ export default async function LanguageLayout(props: LanguageLayoutProps) {
   let translations = {};
 
   // Server uses direct API URL, client uses proxy to avoid CORS
-  // Note: We don't pass apiEndpoint to client - it will use /api-proxy by default
+  // Note: We don't pass apiEndpoint to client - it will use /api/proxy by default
   const _serverApiEndpoint = getJournalApiUrl(journalId); // Used only for server-side fetches
   // Charger la configuration dynamique (couleurs, flags) spécifique au journal
   const journalConfig = getPublicJournalConfig(journalId);

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -519,6 +519,13 @@
         padding: 0 10px;
         min-width: 200px;
 
+        // Focus indicator on the container: the inner input has outline removed,
+        // so keyboard users need a visible ring here (WCAG 2.4.7)
+        &:focus-within {
+          outline: 2px solid var(--focus-color, #0078d4);
+          outline-offset: -2px;
+        }
+
         @media (max-width: breakpoints.$sm) {
           min-width: 150px;
         }
@@ -616,7 +623,13 @@
             color: var(--button-text-on-primary-bg);
           }
 
-          &:focus {
+          &:focus-visible {
+            outline: 2px solid var(--focus-color-on-primary, var(--focus-color));
+            outline-offset: -2px;
+          }
+
+          // Remove focus outline when not using keyboard
+          &:focus:not(:focus-visible) {
             outline: none;
           }
         }

--- a/src/components/LanguageInitializer/LanguageInitializer.tsx
+++ b/src/components/LanguageInitializer/LanguageInitializer.tsx
@@ -49,6 +49,12 @@ function LanguageInitializerClient({ initialLanguage }: LanguageInitializerProps
     if (i18next.language !== lang) {
       i18next.changeLanguage(lang);
     }
+
+    // Keep <html lang> in sync (WCAG 3.1.1) — the root layout renders a static
+    // default because headers() would force dynamic rendering of ISR pages.
+    if (document.documentElement.lang !== lang) {
+      document.documentElement.lang = lang;
+    }
   }, [pathname, initialLanguage, dispatch]);
 
   return null;

--- a/src/components/LanguageInitializer/__tests__/LanguageInitializer.test.tsx
+++ b/src/components/LanguageInitializer/__tests__/LanguageInitializer.test.tsx
@@ -1,0 +1,75 @@
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LanguageInitializer } from '../LanguageInitializer';
+import { setLanguage } from '@/store/features/i18n/i18n.slice';
+
+const mockDispatch = vi.fn();
+const mockUsePathname = vi.fn(() => '/fr/volumes');
+const mockChangeLanguage = vi.fn();
+
+vi.mock('@/hooks/store', () => ({
+  useAppDispatch: () => mockDispatch,
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+vi.mock('i18next', () => ({
+  default: {
+    get language() {
+      return 'en';
+    },
+    changeLanguage: (lang: string) => mockChangeLanguage(lang),
+  },
+}));
+
+describe('LanguageInitializer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.documentElement.lang = 'en';
+    mockUsePathname.mockReturnValue('/fr/volumes');
+  });
+
+  it('syncs document.documentElement.lang with initialLanguage (WCAG 3.1.1)', async () => {
+    render(<LanguageInitializer initialLanguage="fr" />);
+
+    await waitFor(() => {
+      expect(document.documentElement.lang).toBe('fr');
+    });
+  });
+
+  it('derives the language from the pathname when initialLanguage is absent', async () => {
+    mockUsePathname.mockReturnValue('/fr/articles');
+    render(<LanguageInitializer />);
+
+    await waitFor(() => {
+      expect(document.documentElement.lang).toBe('fr');
+    });
+  });
+
+  it('dispatches setLanguage to the store', async () => {
+    render(<LanguageInitializer initialLanguage="fr" />);
+
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith(setLanguage('fr'));
+    });
+  });
+
+  it('changes i18next language when it differs', async () => {
+    render(<LanguageInitializer initialLanguage="fr" />);
+
+    await waitFor(() => {
+      expect(mockChangeLanguage).toHaveBeenCalledWith('fr');
+    });
+  });
+
+  it('does not change i18next language when already in sync', async () => {
+    render(<LanguageInitializer initialLanguage="en" />);
+
+    await waitFor(() => {
+      expect(document.documentElement.lang).toBe('en');
+    });
+    expect(mockChangeLanguage).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -2,6 +2,7 @@
 
 import React, { memo } from 'react';
 import ReactPaginate from 'react-paginate';
+import { useTranslation } from 'react-i18next';
 import {
   CaretLeftBlackIcon,
   CaretLeftGreyLightIcon,
@@ -27,13 +28,10 @@ const Pagination = memo(function Pagination({
   totalItems,
   onPageChange,
 }: IPaginationProps): React.JSX.Element {
+  const { t } = useTranslation();
   const perPage = itemsPerPage ?? DEFAULT_ITEMS_PER_PAGE;
 
   const pageCount = totalItems ? Math.ceil(totalItems / perPage) : 0;
-
-  // Debug loop
-
-  // console.log(`[Pagination] Render: curr=${currentPage}, total=${totalItems}, count=${pageCount}`);
 
   // Ne pas afficher la pagination s'il n'y a pas de pages ou une seule page
 
@@ -45,6 +43,8 @@ const Pagination = memo(function Pagination({
 
   const forcePage = Math.max(0, Math.min(currentPage - 1, pageCount - 1));
 
+  // Note: ReactPaginate already renders <ul role="navigation" aria-label="Pagination">,
+  // so no extra <nav> wrapper is needed (it would create a duplicate landmark).
   return (
     <ReactPaginate
       pageCount={pageCount}
@@ -53,21 +53,28 @@ const Pagination = memo(function Pagination({
       className="pagination"
       pageClassName="pagination-page"
       previousClassName="pagination-previous"
+      previousAriaLabel={
+        currentPage === 1
+          ? t('components.pagination.previousDisabled')
+          : t('components.pagination.previous')
+      }
       previousLabel={
-        currentPage === 1 ? (
-          <CaretLeftGreyLightIcon size={16} ariaLabel="Previous page (disabled)" />
-        ) : (
-          <CaretLeftBlackIcon size={16} ariaLabel="Previous page" />
-        )
+        currentPage === 1 ? <CaretLeftGreyLightIcon size={16} /> : <CaretLeftBlackIcon size={16} />
       }
       nextClassName="pagination-next"
+      nextAriaLabel={
+        currentPage === pageCount
+          ? t('components.pagination.nextDisabled')
+          : t('components.pagination.next')
+      }
       nextLabel={
         currentPage === pageCount ? (
-          <CaretRightGreyLightIcon size={16} ariaLabel="Next page (disabled)" />
+          <CaretRightGreyLightIcon size={16} />
         ) : (
-          <CaretRightBlackIcon size={16} ariaLabel="Next page" />
+          <CaretRightBlackIcon size={16} />
         )
       }
+      ariaLabelBuilder={pageNumber => t('components.pagination.page', { number: pageNumber })}
       activeClassName="pagination-page-active"
       pageRangeDisplayed={3}
       marginPagesDisplayed={2}

--- a/src/components/Pagination/__tests__/Pagination.test.tsx
+++ b/src/components/Pagination/__tests__/Pagination.test.tsx
@@ -4,6 +4,22 @@ import { describe, it, expect, vi } from 'vitest';
 import { checkA11y } from '@/test-utils/axe-helper';
 import Pagination from '../Pagination';
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { number?: number }) => {
+      const translations: Record<string, string> = {
+        'components.pagination.label': 'Pagination',
+        'components.pagination.previous': 'Previous page',
+        'components.pagination.previousDisabled': 'Previous page (disabled)',
+        'components.pagination.next': 'Next page',
+        'components.pagination.nextDisabled': 'Next page (disabled)',
+        'components.pagination.page': `Page ${options?.number ?? ''}`,
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
 // Mock the icon components
 vi.mock('@/components/icons', () => ({
   CaretLeftBlackIcon: ({ size, ariaLabel }: { size: number; ariaLabel?: string }) => (
@@ -110,33 +126,41 @@ describe('Pagination', () => {
     });
   });
 
-  describe('Accessibility - aria-labels on navigation', () => {
-    it('previous icon has aria-label', () => {
+  describe('Accessibility - navigation landmark and aria-labels', () => {
+    it('wraps the pagination in a nav landmark with a localized label', () => {
+      render(<Pagination {...defaultProps} />);
+
+      expect(screen.getByRole('navigation', { name: 'Pagination' })).toBeInTheDocument();
+    });
+
+    it('previous control has a localized aria-label', () => {
       render(<Pagination {...defaultProps} currentPage={2} />);
 
-      const prevIcon = screen.getByTestId('caret-left-black');
-      expect(prevIcon).toHaveAttribute('aria-label', 'Previous page');
+      expect(screen.getByLabelText('Previous page')).toBeInTheDocument();
     });
 
-    it('disabled previous icon has descriptive aria-label', () => {
+    it('disabled previous control has a descriptive aria-label', () => {
       render(<Pagination {...defaultProps} currentPage={1} />);
 
-      const prevIcon = screen.getByTestId('caret-left-grey');
-      expect(prevIcon).toHaveAttribute('aria-label', 'Previous page (disabled)');
+      expect(screen.getByLabelText('Previous page (disabled)')).toBeInTheDocument();
     });
 
-    it('next icon has aria-label', () => {
+    it('next control has a localized aria-label', () => {
       render(<Pagination {...defaultProps} currentPage={1} />);
 
-      const nextIcon = screen.getByTestId('caret-right-black');
-      expect(nextIcon).toHaveAttribute('aria-label', 'Next page');
+      expect(screen.getByLabelText('Next page')).toBeInTheDocument();
     });
 
-    it('disabled next icon has descriptive aria-label', () => {
+    it('disabled next control has a descriptive aria-label', () => {
       render(<Pagination {...defaultProps} currentPage={10} />);
 
-      const nextIcon = screen.getByTestId('caret-right-grey');
-      expect(nextIcon).toHaveAttribute('aria-label', 'Next page (disabled)');
+      expect(screen.getByLabelText('Next page (disabled)')).toBeInTheDocument();
+    });
+
+    it('page links have localized aria-labels', () => {
+      render(<Pagination {...defaultProps} currentPage={2} />);
+
+      expect(screen.getByLabelText('Page 3')).toBeInTheDocument();
     });
   });
 

--- a/src/components/SearchInput/AuthorsSearchInput/AuthorsSearchInput.scss
+++ b/src/components/SearchInput/AuthorsSearchInput/AuthorsSearchInput.scss
@@ -5,6 +5,14 @@
   align-items: center;
   position: relative;
 
+  // Focus indicator on the container: the input itself has outline removed,
+  // so keyboard users need a visible ring here (WCAG 2.4.7)
+  &:focus-within {
+    outline: 2px solid var(--focus-color, #0078d4);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
   &-input {
     color: var(--primary-text);
     font-size: 17px;

--- a/src/components/SearchInput/HeaderSearchInput/HeaderSearchInput.scss
+++ b/src/components/SearchInput/HeaderSearchInput/HeaderSearchInput.scss
@@ -4,6 +4,14 @@
   gap: 20px;
   align-items: center;
 
+  // Focus indicator on the container: the input itself has outline removed,
+  // so keyboard users need a visible ring here (WCAG 2.4.7)
+  &:focus-within {
+    outline: 2px solid var(--focus-color, #0078d4);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
   &-input {
     color: var(--black);
     font-size: 17px;

--- a/src/services/__tests__/article.test.ts
+++ b/src/services/__tests__/article.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { transformArticleForDisplay } from '../article';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { transformArticleForDisplay, fetchArticle } from '../article';
 
 // Mock utils/article
 vi.mock('@/utils/article', () => ({
@@ -7,6 +7,15 @@ vi.mock('@/utils/article', () => ({
     if (raw.forceError) throw new Error('Format failed');
     return { ...raw, formatted: true };
   }),
+}));
+
+vi.mock('@/utils/env-loader', () => ({
+  getJournalApiUrl: vi.fn((code: string) => `https://api.${code}.test`),
+}));
+
+const mockFetchWithRetry = vi.fn();
+vi.mock('@/utils/fetch-with-retry', () => ({
+  fetchWithRetry: (...args: unknown[]) => mockFetchWithRetry(...args),
 }));
 
 describe('article service', () => {
@@ -79,6 +88,45 @@ describe('article service', () => {
     it('should handle null input', () => {
       const result = transformArticleForDisplay(null);
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('fetchArticle', () => {
+    beforeEach(() => {
+      mockFetchWithRetry.mockReset();
+      mockFetchWithRetry.mockResolvedValue({
+        json: async () => ({ paperid: 42, title: 'Test' }),
+      });
+    });
+
+    it('percent-encodes the paper id so it cannot inject path segments', async () => {
+      await fetchArticle('../secret', 'epijinfo');
+
+      const [url] = mockFetchWithRetry.mock.calls[0];
+      expect(url).toContain(encodeURIComponent('../secret'));
+      expect(url).not.toContain('/../');
+    });
+
+    it('percent-encodes a query-string injection attempt', async () => {
+      await fetchArticle('42?admin=true', 'epijinfo');
+
+      const [url] = mockFetchWithRetry.mock.calls[0];
+      expect(url).not.toContain('?admin=true');
+      expect(url).toContain('42%3Fadmin%3Dtrue');
+    });
+
+    it('builds clean cache tags without empty entries when rvcode is absent', async () => {
+      await fetchArticle('42');
+
+      const [, options] = mockFetchWithRetry.mock.calls[0];
+      expect(options.next.tags).toEqual(['articles', 'article-42']);
+    });
+
+    it('includes the journal tag when rvcode is provided', async () => {
+      await fetchArticle('42', 'epijinfo');
+
+      const [, options] = mockFetchWithRetry.mock.calls[0];
+      expect(options.next.tags).toEqual(['articles', 'article-42', 'articles-epijinfo']);
     });
   });
 });

--- a/src/services/article.ts
+++ b/src/services/article.ts
@@ -149,7 +149,9 @@ export async function fetchAcceptedArticles(
  */
 async function fetchRawArticle(paperid: string | number, rvcode: string = ''): Promise<RawArticle> {
   const apiRoot = rvcode ? getJournalApiUrl(rvcode) : API_URL;
-  const response = await fetchWithRetry(`${apiRoot}${API_PATHS.papers}${paperid}`, {
+  // paperid may originate from an upstream API response: encode it so it cannot inject path
+  // segments or query strings into the upstream API URL (consistent with fetchArticle/getArticleById)
+  const response = await fetchWithRetry(`${apiRoot}${API_PATHS.papers}${encodeURIComponent(paperid)}`, {
     next: {
       revalidate: CACHE_TTL.articles,
       tags: ['articles', `article-${paperid}`, rvcode ? `articles-${rvcode}` : ''],

--- a/src/services/article.ts
+++ b/src/services/article.ts
@@ -167,9 +167,15 @@ export async function fetchArticle(
 ): Promise<FetchedArticle | null> {
   try {
     const apiRoot = rvcode ? getJournalApiUrl(rvcode) : API_URL;
-    const response = await fetchWithRetry(`${apiRoot}${API_PATHS.papers}${paperid}`, {
+    // paperid comes from a route param: encode it so it cannot inject path
+    // segments or query strings into the upstream API URL
+    const response = await fetchWithRetry(`${apiRoot}${API_PATHS.papers}${encodeURIComponent(paperid)}`, {
       cache: 'force-cache',
-      next: { tags: ['articles', `article-${paperid}`, rvcode ? `articles-${rvcode}` : ''] },
+      next: {
+        tags: ['articles', `article-${paperid}`, rvcode && `articles-${rvcode}`].filter(
+          Boolean
+        ) as string[],
+      },
     });
     const rawArticle: RawArticle = await response.json();
     return transformArticleForDisplay(rawArticle);
@@ -277,7 +283,7 @@ function createMinimalArticle(rawArticle: any): FetchedArticle | undefined {
 export async function getArticleById(id: string | number): Promise<FetchedArticle | undefined> {
   try {
     const apiRoot = process.env.NEXT_PUBLIC_API_ROOT_ENDPOINT || '';
-    const response = await fetch(`${apiRoot}${API_PATHS.papers}${id}`);
+    const response = await fetch(`${apiRoot}${API_PATHS.papers}${encodeURIComponent(id)}`);
 
     if (!response.ok) {
       throw new Error(`Failed to fetch article. Status: ${response.status}`);

--- a/src/utils/__tests__/fetchInterceptor.test.ts
+++ b/src/utils/__tests__/fetchInterceptor.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetJournalCode = vi.fn((): string => '');
+
+vi.mock('@/utils/static-build', () => ({
+  getJournalCode: () => mockGetJournalCode(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    child: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}));
+
+const realFetch = globalThis.fetch;
+
+/**
+ * Install a mock as the "original" fetch, then (re-)import the interceptor
+ * so it wraps our mock. Returns the mock for assertions.
+ */
+async function installInterceptor(mock: ReturnType<typeof vi.fn>) {
+  globalThis.fetch = mock as unknown as typeof fetch;
+  vi.resetModules();
+  await import('../fetchInterceptor');
+  return mock;
+}
+
+function okResponse() {
+  return new Response('ok', { status: 200 });
+}
+
+describe('fetchInterceptor', () => {
+  beforeEach(() => {
+    mockGetJournalCode.mockReturnValue('');
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.useRealTimers();
+  });
+
+  it('replaces rvcode=default with the current journal code', async () => {
+    mockGetJournalCode.mockReturnValue('epijinfo');
+    const mock = await installInterceptor(vi.fn().mockResolvedValue(okResponse()));
+
+    await globalThis.fetch('https://api.test/pages?rvcode=default');
+
+    expect(mock).toHaveBeenCalledWith(
+      'https://api.test/pages?rvcode=epijinfo',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it('strips only a trailing /default segment', async () => {
+    const mock = await installInterceptor(vi.fn().mockResolvedValue(okResponse()));
+
+    await globalThis.fetch('https://api.test/default-foo/pages/default');
+
+    expect(mock).toHaveBeenCalledWith(
+      'https://api.test/default-foo/pages/',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it('preserves method and body when called with a Request object', async () => {
+    const mock = await installInterceptor(vi.fn().mockResolvedValue(okResponse()));
+
+    const request = new Request('https://api.test/papers', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'hello' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    await globalThis.fetch(request);
+
+    const [target] = mock.mock.calls[0];
+    expect(target).toBeInstanceOf(Request);
+    expect((target as Request).method).toBe('POST');
+    expect(await (target as Request).text()).toBe(JSON.stringify({ title: 'hello' }));
+  });
+
+  it('passes an abort signal that fires on timeout (real cancellation)', async () => {
+    vi.useFakeTimers();
+    let receivedSignal: AbortSignal | undefined;
+    const mock = vi.fn((_input: RequestInfo, init?: RequestInit) => {
+      receivedSignal = init?.signal ?? undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(init.signal!.reason));
+      });
+    });
+    await installInterceptor(mock as unknown as ReturnType<typeof vi.fn>);
+
+    const pending = globalThis.fetch('https://api.test/slow');
+    const assertion = expect(pending).rejects.toThrow('Request timeout');
+
+    await vi.advanceTimersByTimeAsync(15001);
+    await assertion;
+    expect(receivedSignal?.aborted).toBe(true);
+  });
+
+  it('combines the caller signal with the timeout signal', async () => {
+    const mock = vi.fn((_input: RequestInfo, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(init.signal!.reason));
+      });
+    });
+    await installInterceptor(mock as unknown as ReturnType<typeof vi.fn>);
+
+    const controller = new AbortController();
+    const pending = globalThis.fetch('https://api.test/slow', { signal: controller.signal });
+    const assertion = expect(pending).rejects.toThrow();
+
+    controller.abort(new Error('caller aborted'));
+    await assertion;
+  });
+});

--- a/src/utils/__tests__/validation.test.ts
+++ b/src/utils/__tests__/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isValidJournalId, sanitizeIp } from '../validation';
+import { isValidJournalId, sanitizeIp, getClientIp } from '../validation';
 
 describe('isValidJournalId', () => {
   describe('valid journal IDs', () => {
@@ -166,5 +166,40 @@ describe('sanitizeIp', () => {
     it('returns "unknown" for an IPv4 with too many octets (1.2.3.4.5)', () => {
       expect(sanitizeIp('1.2.3.4.5')).toBe('unknown');
     });
+  });
+});
+
+describe('getClientIp', () => {
+  const headersOf = (entries: Record<string, string>) => new Headers(entries);
+
+  it('prefers x-real-ip over x-forwarded-for (spoofing protection)', () => {
+    const headers = headersOf({
+      // Attacker-supplied first entry, nginx-appended real IP last
+      'x-forwarded-for': '10.0.0.1, 203.0.113.7',
+      'x-real-ip': '203.0.113.7',
+    });
+    expect(getClientIp(headers)).toBe('203.0.113.7');
+  });
+
+  it('ignores a spoofed allowlisted IP in x-forwarded-for when x-real-ip is present', () => {
+    const headers = headersOf({
+      'x-forwarded-for': '192.168.1.100',
+      'x-real-ip': '198.51.100.9',
+    });
+    expect(getClientIp(headers)).toBe('198.51.100.9');
+  });
+
+  it('falls back to x-forwarded-for when x-real-ip is absent', () => {
+    const headers = headersOf({ 'x-forwarded-for': '203.0.113.7, 10.0.0.1' });
+    expect(getClientIp(headers)).toBe('203.0.113.7');
+  });
+
+  it('returns "unknown" when neither header is present', () => {
+    expect(getClientIp(headersOf({}))).toBe('unknown');
+  });
+
+  it('returns "unknown" for an invalid x-real-ip value', () => {
+    const headers = headersOf({ 'x-real-ip': 'not-an-ip' });
+    expect(getClientIp(headers)).toBe('unknown');
   });
 });

--- a/src/utils/env-loader.ts
+++ b/src/utils/env-loader.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { isValidJournalId } from './validation';
+import { isValidJournalId, sanitizeForLog } from './validation';
 import { API_ROOT_ENDPOINT } from '@/config/api';
 import { logger } from '@/lib/logger';
 
@@ -68,12 +68,12 @@ export function loadJournalConfig(journalCode: string): JournalConfig {
     return { code: journalCode, env: {} };
   }
 
-  // Validate journal code format to prevent path traversal attacks
+  // Validate journal code format to prevent path traversal attacks.
+  // Do NOT cache invalid codes: they are attacker-controlled arbitrary strings
+  // and caching them would let the map grow without bound.
   if (!isValidJournalId(journalCode)) {
-    log.warn(`Invalid journal code format: ${journalCode}`);
-    const emptyConfig = { code: journalCode, env: {} };
-    configCache.set(journalCode, emptyConfig);
-    return emptyConfig;
+    log.warn(`Invalid journal code format: ${sanitizeForLog(journalCode)}`);
+    return { code: journalCode, env: {} };
   }
 
   // Return cached config if available

--- a/src/utils/fetchInterceptor.ts
+++ b/src/utils/fetchInterceptor.ts
@@ -30,8 +30,10 @@ const API_CONFIG = {
 
 // Global fetch function replacement
 globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-  let url = input.toString();
-  const method = init?.method || 'GET';
+  const isRequest = input instanceof Request;
+  const originalUrl = isRequest ? input.url : input.toString();
+  let url = originalUrl;
+  const method = init?.method || (isRequest ? input.method : 'GET');
 
   let journalCode = '';
   try {
@@ -47,20 +49,36 @@ globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise
     }
   }
 
-  // Handle redirection of requests to /default
-  if (url.endsWith('/default') || url === 'default') {
-    url = url.replace('/default', '/').replace('default', '/');
+  // Handle redirection of requests to /default — only strip the trailing segment,
+  // never other occurrences of "default" earlier in the URL
+  if (url.endsWith('/default')) {
+    url = url.slice(0, -'default'.length);
+  } else if (url === 'default') {
+    url = '/';
   }
 
   log.debug(`${method} ${url}`);
 
+  // Timeout via AbortController so the underlying request is actually cancelled
+  // (a Promise.race would leave the socket open after rejecting)
+  const timeoutController = new AbortController();
+  const timeoutId = setTimeout(
+    () => timeoutController.abort(new Error('Request timeout')),
+    API_CONFIG.timeout
+  );
+  const callerSignal = init?.signal ?? (isRequest ? input.signal : null);
+  const signal = callerSignal
+    ? AbortSignal.any([callerSignal, timeoutController.signal])
+    : timeoutController.signal;
+
   try {
-    const response = (await Promise.race([
-      originalFetch(url, init),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('Request timeout')), API_CONFIG.timeout)
-      ),
-    ])) as Response;
+    // Preserve Request objects (method, body, headers) — only rebuild when the URL was rewritten
+    const target: RequestInfo = isRequest
+      ? url === originalUrl
+        ? input
+        : new Request(url, input)
+      : url;
+    const response = await originalFetch(target, { ...init, signal });
 
     log.debug(`${response.status} ${url}`);
 
@@ -68,6 +86,8 @@ globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise
   } catch (error) {
     log.error(`${(error as Error).message} for ${url}`);
     throw error;
+  } finally {
+    clearTimeout(timeoutId);
   }
 };
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -48,6 +48,21 @@ export function sanitizeIp(raw: string | null): string {
 }
 
 /**
+ * Resolve the client IP from request headers for rate limiting and IP allowlisting.
+ *
+ * Prefers x-real-ip (set by the trusted reverse proxy from the socket address) over
+ * x-forwarded-for: nginx APPENDS the real IP to any client-supplied x-forwarded-for,
+ * so its first entry is attacker-controlled — trusting it would allow spoofing an
+ * allowlisted IP or rotating fake IPs to bypass rate limits.
+ *
+ * @param headers - Request headers (any object exposing .get(name))
+ * @returns A structurally valid IP string or 'unknown'
+ */
+export function getClientIp(headers: { get(name: string): string | null }): string {
+  return sanitizeIp(headers.get('x-real-ip') ?? headers.get('x-forwarded-for'));
+}
+
+/**
  * Sanitize a value for safe logging (prevents log injection via newlines/control chars)
  *
  * @param value - Raw user-controlled value to sanitize


### PR DESCRIPTION
## Summary

Remediation of the findings from a full security / bugs / Next.js / accessibility audit of the codebase. Nine focused commits, each self-contained with tests.

### Security
- **Trusted client IP** (`getClientIp()`): prefer `x-real-ip` (set by nginx from the socket address) over `x-forwarded-for`, whose first entry is client-controlled — closes an IP-allowlist spoofing vector on `/api/revalidate` and rate-limit bypass on the proxies.
- **`/api-proxy` rewrite is now opt-in** via `API_PROXY_TARGET`: it was an always-on, unauthenticated, un-rate-limited pass-through to the API, unused by the app. Local-dev CORS workflow (`docs/LOCAL_TESTING_GUIDE.md`) is preserved.
- **Article id validation**: `download`/`preview` routes now enforce `/^\d+$/` (aligned with `linkset`/`[format]`), and `fetchArticle`/`getArticleById` percent-encode the id so it cannot inject path segments or query strings into upstream URLs.
- **nginx**: direct requests to internal `/sites/...` multi-tenant paths return 404 (both templates); internal middleware rewrites unaffected.
- **Hardening**: `poweredByHeader: false`; `loadJournalConfig` no longer caches invalid (attacker-controlled) journal codes.

### Bug fixes
- **Global fetch interceptor**: timed-out requests are now actually aborted (AbortController instead of `Promise.race`), the caller's signal is honoured via `AbortSignal.any`, `Request` objects keep their method/body/headers, and the `/default` rewrite no longer corrupts URLs containing `default` elsewhere.
- **Dynamic API proxy**: 15s upstream timeout on GET/POST with a proper 504.

### Accessibility
- **`<html lang>`** now synced with the active language on the client (WCAG 3.1.1) — SSR keeps the static default to avoid forcing dynamic rendering of ISR pages.
- **Visible keyboard focus** restored on header/authors search inputs via `:focus-within` (WCAG 2.4.7).
- **Pagination**: previous/next/page aria-labels localized (new `components.pagination.*` keys in fr/en/es) and carried by the links; no duplicate `<nav>` landmark (react-paginate already renders one).

## Test plan
- [x] Full suite: **2412 tests / 136 files passing** (16 new tests: getClientIp, fetchInterceptor, article id injection, proxy timeout, LanguageInitializer, pagination a11y)
- [x] `npm run lint` clean, `tsc --noEmit` clean (outside known pre-existing test-file errors)
- [x] `next.config.js` verified: `rewrites()` returns `[]` without `API_PROXY_TARGET`, `poweredByHeader: false`
- [ ] Deploy note: nginx template change requires a config reload; verify `X-Real-IP` is set by the proxy in front (it is in both templates)