### PR TITLE
fix: block cross-journal article access

### DIFF
--- a/src/app/sites/[journalId]/[lang]/articles/[id]/__tests__/page.test.tsx
+++ b/src/app/sites/[journalId]/[lang]/articles/[id]/__tests__/page.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/services/article', () => ({
+  fetchArticle: vi.fn(),
+  fetchArticles: vi.fn(),
+  fetchArticleMetadata: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@/services/volume', () => ({
+  fetchVolume: vi.fn(),
+}));
+
+vi.mock('@/services/journal', () => ({
+  getJournalByCode: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/utils/server-i18n', () => ({
+  getServerTranslations: vi.fn().mockResolvedValue({}),
+  t: vi.fn((key: string) => key),
+  defaultLanguage: 'en',
+  availableLanguages: ['en', 'fr'],
+}));
+
+vi.mock('@/utils/language-utils', () => ({
+  getLanguageFromParams: vi.fn(() => 'fr'),
+  acceptedLanguages: ['en', 'fr'],
+}));
+
+vi.mock('@/utils/static-params-helper', () => ({
+  combineWithLanguageParams: vi.fn(),
+}));
+
+vi.mock('@/utils/build-progress', () => ({
+  initBuildProgress: vi.fn(),
+  logArticleProgress: vi.fn(),
+}));
+
+vi.mock('@/utils/env-loader', () => ({
+  loadJournalConfig: vi.fn(() => ({ env: {} })),
+}));
+
+vi.mock('@/utils/signposting', () => ({
+  getJournalBaseUrl: vi.fn(() => 'https://requested-journal.episciences.org'),
+}));
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => {
+    const error = new Error('NEXT_NOT_FOUND') as Error & { digest: string };
+    error.digest = 'NEXT_NOT_FOUND';
+    throw error;
+  }),
+}));
+
+import { fetchArticle } from '@/services/article';
+import { notFound } from 'next/navigation';
+
+function makeProps(journalId: string, id = '18632') {
+  return { params: Promise.resolve({ id, lang: 'fr', journalId }) };
+}
+
+describe('ArticleDetailsPage — cross-journal access guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('blocks access when the article belongs to a different journal', async () => {
+    vi.mocked(fetchArticle).mockResolvedValue({
+      id: 18632,
+      journalCode: 'fajpc',
+      title: 'Some article',
+      authors: [],
+    } as never);
+
+    const { default: ArticleDetailsPage } = await import('../page');
+
+    await expect(ArticleDetailsPage(makeProps('slovo'))).rejects.toThrow();
+    expect(notFound).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders when the article belongs to the requested journal', async () => {
+    vi.mocked(fetchArticle).mockResolvedValue({
+      id: 18632,
+      journalCode: 'fajpc',
+      title: 'Some article',
+      authors: [],
+    } as never);
+
+    const { default: ArticleDetailsPage } = await import('../page');
+
+    const result = await ArticleDetailsPage(makeProps('fajpc'));
+    expect(result).toBeTruthy();
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it('renders when journalCode is absent from the API payload (best-effort check only)', async () => {
+    vi.mocked(fetchArticle).mockResolvedValue({
+      id: 18632,
+      title: 'Some article',
+      authors: [],
+    } as never);
+
+    const { default: ArticleDetailsPage } = await import('../page');
+
+    const result = await ArticleDetailsPage(makeProps('fajpc'));
+    expect(result).toBeTruthy();
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 (notFound) when fetchArticle resolves to null', async () => {
+    vi.mocked(fetchArticle).mockResolvedValue(null);
+
+    const { default: ArticleDetailsPage } = await import('../page');
+
+    await expect(ArticleDetailsPage(makeProps('fajpc'))).rejects.toThrow();
+    expect(notFound).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/sites/[journalId]/[lang]/articles/[id]/download/__tests__/route.test.ts
+++ b/src/app/sites/[journalId]/[lang]/articles/[id]/download/__tests__/route.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/services/article', () => ({
+  fetchArticle: vi.fn(),
+}));
+
+vi.mock('@/utils/pdf', () => ({
+  generateArticleFilename: vi.fn(() => 'article.pdf'),
+  isAllowedPdfDomain: vi.fn(() => true),
+}));
+
+vi.mock('@/utils/validation', () => ({
+  isValidJournalId: vi.fn(() => true),
+}));
+
+import { fetchArticle } from '@/services/article';
+
+function makeRequest(journalId: string, id: string): NextRequest {
+  return new NextRequest(`http://localhost/sites/${journalId}/fr/articles/${id}/download`);
+}
+
+function makeContext(journalId: string, id: string) {
+  return { params: Promise.resolve({ journalId, lang: 'fr' as const, id }) };
+}
+
+describe('GET /articles/[id]/download', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it('returns 404 when the article belongs to a different journal', async () => {
+    vi.mocked(fetchArticle).mockResolvedValue({
+      id: 18632,
+      journalCode: 'fajpc',
+      pdfLink: 'https://hal.science/hal-05671009v1/document',
+      title: 'Some article',
+      authors: [],
+    } as never);
+
+    const { GET } = await import('../route');
+    const res = await GET(makeRequest('slovo', '18632'), makeContext('slovo', '18632'));
+
+    expect(res.status).toBe(404);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('serves the PDF when the article belongs to the requested journal', async () => {
+    vi.mocked(fetchArticle).mockResolvedValue({
+      id: 18632,
+      journalCode: 'fajpc',
+      pdfLink: 'https://hal.science/hal-05671009v1/document',
+      title: 'Some article',
+      authors: [],
+    } as never);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      new Response('%PDF-1.4', { status: 200, headers: { 'Content-Length': '8' } })
+    );
+
+    const { GET } = await import('../route');
+    const res = await GET(makeRequest('fajpc', '18632'), makeContext('fajpc', '18632'));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/pdf');
+  });
+
+  it('serves the PDF when journalCode is absent from the payload', async () => {
+    vi.mocked(fetchArticle).mockResolvedValue({
+      id: 18632,
+      pdfLink: 'https://hal.science/hal-05671009v1/document',
+      title: 'Some article',
+      authors: [],
+    } as never);
+    vi.mocked(global.fetch).mockResolvedValueOnce(new Response('%PDF-1.4', { status: 200 }));
+
+    const { GET } = await import('../route');
+    const res = await GET(makeRequest('fajpc', '18632'), makeContext('fajpc', '18632'));
+
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 404 when the article has no PDF link', async () => {
+    vi.mocked(fetchArticle).mockResolvedValue({
+      id: 18632,
+      journalCode: 'fajpc',
+      title: 'Some article',
+      authors: [],
+    } as never);
+
+    const { GET } = await import('../route');
+    const res = await GET(makeRequest('fajpc', '18632'), makeContext('fajpc', '18632'));
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/sites/[journalId]/[lang]/articles/[id]/download/route.ts
+++ b/src/app/sites/[journalId]/[lang]/articles/[id]/download/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { fetchArticle } from '@/services/article';
+import { isCrossJournalAccess } from '@/utils/article';
 import { generateArticleFilename, isAllowedPdfDomain } from '@/utils/pdf';
 import { isValidJournalId } from '@/utils/validation';
 import { AvailableLanguage } from '@/utils/i18n';
@@ -24,7 +25,7 @@ export async function GET(
     return new NextResponse(null, { status: 404 });
   }
 
-  if (article.journalCode !== undefined && article.journalCode !== journalId) {
+  if (isCrossJournalAccess(article, journalId, { route: 'download', resourceId: id })) {
     return new NextResponse(null, { status: 404 });
   }
 

--- a/src/app/sites/[journalId]/[lang]/articles/[id]/download/route.ts
+++ b/src/app/sites/[journalId]/[lang]/articles/[id]/download/route.ts
@@ -24,6 +24,10 @@ export async function GET(
     return new NextResponse(null, { status: 404 });
   }
 
+  if (article.journalCode !== undefined && article.journalCode !== journalId) {
+    return new NextResponse(null, { status: 404 });
+  }
+
   if (!isAllowedPdfDomain(article.pdfLink)) {
     return new NextResponse('Invalid PDF source', { status: 403 });
   }

--- a/src/app/sites/[journalId]/[lang]/articles/[id]/linkset/__tests__/route.test.ts
+++ b/src/app/sites/[journalId]/[lang]/articles/[id]/linkset/__tests__/route.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/services/article', () => ({
+  fetchArticle: vi.fn(),
+}));
+
+vi.mock('@/utils/signposting', () => ({
+  getJournalBaseUrl: vi.fn((journalId: string) => `https://${journalId}.episciences.org`),
+  SIGNPOSTING_FORMATS: [{ format: 'bibtex', type: 'application/x-bibtex' }],
+}));
+
+import { fetchArticle } from '@/services/article';
+
+function makeRequest(journalId: string, id: string): NextRequest {
+  return new NextRequest(`http://localhost/sites/${journalId}/fr/articles/${id}/linkset`);
+}
+
+function makeContext(journalId: string, id: string) {
+  return { params: Promise.resolve({ journalId, lang: 'fr', id }) };
+}
+
+describe('GET /articles/[id]/linkset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 404 when the article belongs to a different journal', async () => {
+    vi.mocked(fetchArticle).mockResolvedValue({
+      id: 18632,
+      journalCode: 'fajpc',
+      authors: [],
+      title: 'Some article',
+    } as never);
+
+    const { GET } = await import('../route');
+    const res = await GET(makeRequest('slovo', '18632'), makeContext('slovo', '18632'));
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns the linkset when the article belongs to the requested journal', async () => {
+    vi.mocked(fetchArticle).mockResolvedValue({
+      id: 18632,
+      journalCode: 'fajpc',
+      authors: [],
+      title: 'Some article',
+    } as never);
+
+    const { GET } = await import('../route');
+    const res = await GET(makeRequest('fajpc', '18632'), makeContext('fajpc', '18632'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.linkset[0].anchor).toBe('https://fajpc.episciences.org/fr/articles/18632');
+  });
+
+  it('returns the linkset when journalCode is absent from the payload', async () => {
+    vi.mocked(fetchArticle).mockResolvedValue({
+      id: 18632,
+      authors: [],
+      title: 'Some article',
+    } as never);
+
+    const { GET } = await import('../route');
+    const res = await GET(makeRequest('fajpc', '18632'), makeContext('fajpc', '18632'));
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/sites/[journalId]/[lang]/articles/[id]/linkset/route.ts
+++ b/src/app/sites/[journalId]/[lang]/articles/[id]/linkset/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { fetchArticle } from '@/services/article';
+import { isCrossJournalAccess } from '@/utils/article';
 import { getJournalBaseUrl, SIGNPOSTING_FORMATS } from '@/utils/signposting';
 
 export async function GET(
@@ -17,7 +18,7 @@ export async function GET(
     return new NextResponse('Not found', { status: 404 });
   }
 
-  if (article.journalCode !== undefined && article.journalCode !== journalId) {
+  if (isCrossJournalAccess(article, journalId, { route: 'linkset', resourceId: id })) {
     return new NextResponse('Not found', { status: 404 });
   }
 

--- a/src/app/sites/[journalId]/[lang]/articles/[id]/linkset/route.ts
+++ b/src/app/sites/[journalId]/[lang]/articles/[id]/linkset/route.ts
@@ -17,6 +17,10 @@ export async function GET(
     return new NextResponse('Not found', { status: 404 });
   }
 
+  if (article.journalCode !== undefined && article.journalCode !== journalId) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
   const baseUrl = getJournalBaseUrl(journalId);
   const articleUrl = `${baseUrl}/${lang}/articles/${id}`;
 

--- a/src/app/sites/[journalId]/[lang]/articles/[id]/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/articles/[id]/page.tsx
@@ -169,9 +169,10 @@ export default async function ArticleDetailsPage(props: ArticleDetailsPageProps)
       notFound();
     }
 
-    // Tier 2: best-effort check — only triggers when the API returns `journalCode`.
-    // Primary protection is Tier 1: the request already used a journal-scoped API base URL,
-    // so a cross-journal article would have returned null (404) above.
+    // Cross-journal access guard: the upstream papers API is global (not journal-scoped),
+    // so a paper ID always resolves regardless of which journal's base URL was used.
+    // The journal that actually owns the article is reported in the payload itself
+    // (document.database.current.journal.code), so we must check it explicitly.
     if (article.journalCode !== undefined && article.journalCode !== journalId) {
       logger.warn('Cross-journal article access blocked', {
         reason: 'article-wrong-journal',

--- a/src/app/sites/[journalId]/[lang]/articles/[id]/page.tsx
+++ b/src/app/sites/[journalId]/[lang]/articles/[id]/page.tsx
@@ -6,7 +6,7 @@ import { fetchVolume } from '@/services/volume';
 import { getJournalByCode } from '@/services/journal';
 import ArticleDetailsClient from './ArticleDetailsClient';
 import ArticleDetailsServer from './ArticleDetailsServer';
-import { FetchedArticle, METADATA_TYPE } from '@/utils/article';
+import { FetchedArticle, isCrossJournalAccess, METADATA_TYPE } from '@/utils/article';
 import { IArticle } from '@/types/article';
 import { IVolume } from '@/types/volume';
 import { getServerTranslations, t, defaultLanguage, availableLanguages } from '@/utils/server-i18n';
@@ -169,18 +169,8 @@ export default async function ArticleDetailsPage(props: ArticleDetailsPageProps)
       notFound();
     }
 
-    // Cross-journal access guard: the upstream papers API is global (not journal-scoped),
-    // so a paper ID always resolves regardless of which journal's base URL was used.
-    // The journal that actually owns the article is reported in the payload itself
-    // (document.database.current.journal.code), so we must check it explicitly.
-    if (article.journalCode !== undefined && article.journalCode !== journalId) {
-      logger.warn('Cross-journal article access blocked', {
-        reason: 'article-wrong-journal',
-        resourceType: 'article',
-        resourceId: id,
-        articleJournalCode: article.journalCode,
-        requestedJournalCode: journalId,
-      });
+    // Cross-journal access guard: see isCrossJournalAccess() for rationale.
+    if (isCrossJournalAccess(article, journalId, { route: 'details', resourceId: id })) {
       notFound();
     }
 

--- a/src/app/sites/[journalId]/[lang]/articles/[id]/preview/__tests__/route.test.ts
+++ b/src/app/sites/[journalId]/[lang]/articles/[id]/preview/__tests__/route.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/services/article', () => ({
+  fetchArticle: vi.fn(),
+}));
+
+vi.mock('@/utils/pdf', () => ({
+  isAllowedPdfDomain: vi.fn(() => true),
+}));
+
+vi.mock('@/utils/validation', () => ({
+  isValidJournalId: vi.fn(() => true),
+  sanitizeForLog: vi.fn((v: string) => v),
+}));
+
+import { fetchArticle } from '@/services/article';
+
+function makeRequest(journalId: string, id: string): NextRequest {
+  return new NextRequest(`http://localhost/sites/${journalId}/fr/articles/${id}/preview`);
+}
+
+function makeContext(journalId: string, id: string) {
+  return { params: Promise.resolve({ journalId, lang: 'fr' as const, id }) };
+}
+
+describe('GET /articles/[id]/preview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it('returns 404 when the article belongs to a different journal', async () => {
+    vi.mocked(fetchArticle).mockResolvedValue({
+      id: 18632,
+      journalCode: 'fajpc',
+      pdfLink: 'https://hal.science/hal-05671009v1/document',
+      title: 'Some article',
+      authors: [],
+    } as never);
+
+    const { GET } = await import('../route');
+    const res = await GET(makeRequest('slovo', '18632'), makeContext('slovo', '18632'));
+
+    expect(res.status).toBe(404);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('serves the PDF preview when the article belongs to the requested journal', async () => {
+    vi.mocked(fetchArticle).mockResolvedValue({
+      id: 18632,
+      journalCode: 'fajpc',
+      pdfLink: 'https://hal.science/hal-05671009v1/document',
+      title: 'Some article',
+      authors: [],
+    } as never);
+    vi.mocked(global.fetch).mockResolvedValueOnce(new Response('%PDF-1.4', { status: 200 }));
+
+    const { GET } = await import('../route');
+    const res = await GET(makeRequest('fajpc', '18632'), makeContext('fajpc', '18632'));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/pdf');
+  });
+
+  it('serves the PDF preview when journalCode is absent from the payload', async () => {
+    vi.mocked(fetchArticle).mockResolvedValue({
+      id: 18632,
+      pdfLink: 'https://hal.science/hal-05671009v1/document',
+      title: 'Some article',
+      authors: [],
+    } as never);
+    vi.mocked(global.fetch).mockResolvedValueOnce(new Response('%PDF-1.4', { status: 200 }));
+
+    const { GET } = await import('../route');
+    const res = await GET(makeRequest('fajpc', '18632'), makeContext('fajpc', '18632'));
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/sites/[journalId]/[lang]/articles/[id]/preview/route.ts
+++ b/src/app/sites/[journalId]/[lang]/articles/[id]/preview/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { fetchArticle } from '@/services/article';
+import { isCrossJournalAccess } from '@/utils/article';
 import { isAllowedPdfDomain } from '@/utils/pdf';
 import { isValidJournalId, sanitizeForLog } from '@/utils/validation';
 import { AvailableLanguage } from '@/utils/i18n';
@@ -39,10 +40,7 @@ export async function GET(
     return new NextResponse('Article not found', { status: 404, headers: errorHeaders });
   }
 
-  if (article.journalCode !== undefined && article.journalCode !== journalId) {
-    logger.warn(
-      `[preview] ❌ Cross-journal article access blocked: article ${id} belongs to ${article.journalCode}, requested via ${journalId}`
-    );
+  if (isCrossJournalAccess(article, journalId, { route: 'preview', resourceId: id })) {
     return new NextResponse('Article not found', { status: 404, headers: errorHeaders });
   }
 

--- a/src/app/sites/[journalId]/[lang]/articles/[id]/preview/route.ts
+++ b/src/app/sites/[journalId]/[lang]/articles/[id]/preview/route.ts
@@ -39,6 +39,13 @@ export async function GET(
     return new NextResponse('Article not found', { status: 404, headers: errorHeaders });
   }
 
+  if (article.journalCode !== undefined && article.journalCode !== journalId) {
+    logger.warn(
+      `[preview] ❌ Cross-journal article access blocked: article ${id} belongs to ${article.journalCode}, requested via ${journalId}`
+    );
+    return new NextResponse('Article not found', { status: 404, headers: errorHeaders });
+  }
+
   if (!article.pdfLink) {
     logger.warn(`[preview] ⚠️ Article ${id} (${journalId}) has no PDF link`);
     return new NextResponse('No PDF link available', { status: 404, headers: errorHeaders });

--- a/src/services/article.ts
+++ b/src/services/article.ts
@@ -270,6 +270,7 @@ function createMinimalArticle(rawArticle: any): FetchedArticle | undefined {
 
   return {
     id: Number(rawArticle.paperid) || rawArticle.docid,
+    journalCode: rawArticle.document?.database?.current?.journal?.code,
     title:
       rawArticle.document?.journal?.journal_article?.titles?.title ||
       `Article ${rawArticle.paperid || rawArticle.docid}`,

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -110,7 +110,6 @@ export interface IClassificationItem {
 
 export type RawArticle = IPartialArticle &
   IArticle & {
-    rvcode?: string;
     document: {
       journal?: {
         journal_article: IRawArticleContent;

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -166,6 +166,12 @@ export type RawArticle = IPartialArticle &
             id: number;
             titles: Record<AvailableLanguage, string>;
           };
+          journal?: {
+            id: number;
+            url: string;
+            code: string;
+            name: string;
+          };
           classifications?: {
             msc2020?: {
               [code: string]: {

--- a/src/utils/__tests__/formatArticle.test.ts
+++ b/src/utils/__tests__/formatArticle.test.ts
@@ -18,7 +18,6 @@ function makeRaw(overrides: {
   database?: Record<string, unknown>;
   paperid?: number;
   doi?: string;
-  rvcode?: string;
   keywords?: unknown;
 }): RawArticle {
   const content = {
@@ -33,7 +32,6 @@ function makeRaw(overrides: {
     '@type': 'Article',
     paperid: overrides.paperid ?? 42,
     doi: overrides.doi,
-    rvcode: overrides.rvcode,
     keywords: overrides.keywords,
     document: {
       journal: { journal_article: content },
@@ -96,7 +94,6 @@ describe('formatArticle', () => {
     it('maps core metadata from the database node', () => {
       const raw = makeRaw({
         paperid: 99,
-        rvcode: 'epijournal',
         database: {
           flag: 'imported',
           type: { title: 'Article' },
@@ -110,6 +107,7 @@ describe('formatArticle', () => {
           mainPdfUrl: 'https://hal/pdf',
           volume: { id: 12 },
           graphical_abstract_file: 'ga.png',
+          journal: { id: 1, url: 'https://epijournal.episciences.org', code: 'epijournal', name: 'Epijournal' },
         },
       });
       const result = formatArticle(raw);

--- a/src/utils/article.ts
+++ b/src/utils/article.ts
@@ -48,6 +48,40 @@ export enum METADATA_TYPE {
 
 export type FetchedArticle = IArticle | undefined;
 
+/**
+ * Guards against the upstream papers API being global (not journal-scoped): a paper ID
+ * resolves regardless of which journal's base URL built the request, so ownership must be
+ * checked against the journal code reported in the payload itself. Logs a warning both when
+ * access is blocked and when `journalCode` is missing (guard inactive), so a silent bypass
+ * stays observable instead of failing open unnoticed.
+ */
+export function isCrossJournalAccess(
+  article: Pick<IArticle, 'journalCode'>,
+  journalId: string,
+  context: { route: string; resourceId: string }
+): boolean {
+  if (article.journalCode === undefined) {
+    log.warn('Article journalCode missing from API payload — cross-journal guard inactive', {
+      route: context.route,
+      resourceId: context.resourceId,
+      requestedJournalCode: journalId,
+    });
+    return false;
+  }
+
+  if (article.journalCode !== journalId) {
+    log.warn('Cross-journal article access blocked', {
+      route: context.route,
+      resourceId: context.resourceId,
+      articleJournalCode: article.journalCode,
+      requestedJournalCode: journalId,
+    });
+    return true;
+  }
+
+  return false;
+}
+
 // Type étendu pour ajouter le champ docid qui existe dans les réponses de l'API
 // mais qui n'est pas officiellement dans le type RawArticle
 interface ExtendedRawArticle extends RawArticle {

--- a/src/utils/article.ts
+++ b/src/utils/article.ts
@@ -396,7 +396,7 @@ export function formatArticle(article: RawArticle): FetchedArticle {
 
     return {
       id,
-      journalCode: extendedArticle.rvcode,
+      journalCode: articleDB?.current?.journal?.code,
       title: articleContent.titles?.title,
       abstract: extractAbstract(articleContent),
       graphicalAbstract: articleDB?.current?.graphical_abstract_file,


### PR DESCRIPTION
## Summary
- Any journal's site could serve, download the PDF of, preview the PDF of, or expose the linkset for **any other journal's** article by guessing/reusing a paper ID (e.g. `https://slovo.episciences.org/fr/articles/18632` served fajpc's article 18632).
- Root cause: the upstream papers API is global (same base URL for every journal), so a paper ID resolves regardless of the journal used to build the request. A safety check already existed (`article.journalCode !== journalId`) but was dead code — it read `rawArticle.rvcode`, a field that doesn't exist in the real API payload. The actual journal code lives at `document.database.current.journal.code`.
- Fixed the field extraction so the existing guard actually works, and applied the same guard to `download`, `preview`, and `linkset` routes, which had the same hole (`[format]` export route was verified safe — the backend already validates the `code` query param there).

## Test plan
- [x] `npx vitest run` — 2429 tests passing
- [x] `npx tsc --noEmit` — clean
- [x] Added regression tests for the details page and the three routes (cross-journal request → 404 / notFound; same-journal request → served normally); confirmed by temporarily disabling each guard and observing the new tests fail
- [x] Verified against the real API (`api.episciences.org`) that `rvcode` is absent from paper payloads and the journal code is at `document.database.current.journal.code`