### PR TITLE
fix(cache): use deterministic build ID to fix Valkey cache thrashing

### DIFF
--- a/deployment/ansible/rollback.yml
+++ b/deployment/ansible/rollback.yml
@@ -11,3 +11,30 @@
 
   roles:
     - ansistrano.rollback
+
+# The role above only switches the `current` symlink back to the previous
+# release. The running Node process resolved that symlink once at startup
+# and keeps serving the old (broken) release from memory until restarted —
+# so without this play, a rollback silently does nothing.
+- name: Rolling restart after rollback (one server at a time)
+  hosts: all
+  gather_facts: false
+  serial: 1
+
+  tasks:
+    - name: Reload systemd daemon
+      ansible.builtin.command:
+        cmd: sudo /bin/systemctl daemon-reload
+      changed_when: true
+
+    - name: Restart episciences-next service
+      ansible.builtin.command:
+        cmd: sudo /bin/systemctl restart episciences-front-next
+      changed_when: true
+
+    - name: Wait for service to be healthy
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: 3000
+        delay: 3
+        timeout: 30

--- a/deployment/ansible/tasks/build.yml
+++ b/deployment/ansible/tasks/build.yml
@@ -27,12 +27,26 @@
     ci: true
     production: false
 
+# The release directory itself has no .git (Ansistrano exports the checked-out
+# commit into releases/<id>/ without the repo metadata, which only lives in the
+# persistent repo/ cache). next.config.js's own `git rev-parse` therefore fails
+# there and falls back to 'unknown' — pass the real SHA in explicitly so the
+# deterministic build ID (see next.config.js generateBuildId) reflects the
+# actual deployed commit instead of a constant that never changes.
+- name: Read deployed commit SHA from the Ansistrano repo cache
+  ansible.builtin.command:
+    cmd: git rev-parse --short HEAD
+    chdir: '{{ ansistrano_deploy_to }}/repo'
+  register: deployed_git_sha
+  changed_when: false
+
 - name: Build Next.js application
   ansible.builtin.command:
     cmd: npm run build
     chdir: '{{ ansistrano_release_path.stdout }}'
   environment:
     NODE_ENV: production
+    NEXT_BUILD_GIT_SHA: '{{ deployed_git_sha.stdout }}'
   changed_when: true
 
 - name: Copy static assets into standalone output

--- a/docs/ISR_STRATEGY.md
+++ b/docs/ISR_STRATEGY.md
@@ -50,10 +50,18 @@ Pages that rarely change. On-demand revalidation is the only way to update them.
 | About                     | `/sites/[journalId]/[lang]/about`                     |
 | Credits                   | `/sites/[journalId]/[lang]/credits`                   |
 | For authors               | `/sites/[journalId]/[lang]/for-authors`               |
+| For editors               | `/sites/[journalId]/[lang]/for-editors`               |
 | For reviewers             | `/sites/[journalId]/[lang]/for-reviewers`             |
 | For conference organisers | `/sites/[journalId]/[lang]/for-conference-organisers` |
 | Acknowledgements          | `/sites/[journalId]/[lang]/acknowledgements`          |
 | Indexing                  | `/sites/[journalId]/[lang]/indexing`                  |
+| Ethical charter           | `/sites/[journalId]/[lang]/ethical-charter`           |
+| Proposing special issues  | `/sites/[journalId]/[lang]/proposing-special-issues`  |
+| Accessibility\*           | `/sites/[journalId]/[lang]/accessibility`             |
+
+\* Accessibility has no backing API service — its content is read from a local markdown
+file at build time (`fs.readFileSync`), not `fetch()`. It has no Data Cache entry and
+`CACHE_TTL_PAGES` does not apply to it; it can only change via a new deployment.
 
 ### Dynamic Pages (Daily ISR)
 
@@ -93,15 +101,19 @@ Published content is effectively immutable; on-demand revalidation handles corre
 All fetch-level cache durations are configurable. They default to **3600 s (1 hour)**
 when the variable is not set. Set to `false` to cache indefinitely (on-demand only).
 
-| Variable               | Service(s)                                                                                                                                                               | Default |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
-| `CACHE_TTL_NEWS`       | `news.ts`                                                                                                                                                                | 3600    |
-| `CACHE_TTL_VOLUMES`    | `volume.ts`                                                                                                                                                              | 3600    |
-| `CACHE_TTL_ARTICLES`   | `article.ts`, `section.ts`                                                                                                                                               | 3600    |
-| `CACHE_TTL_PAGES`      | `about.ts`, `credits.ts`, `forReviewers.ts`, `indexing.ts`, `indexation.ts`, `acknowledgements.ts`, `forConferenceOrganisers.ts`, `proposingSpecialIssues.ts`, `page.ts` | 3600    |
-| `CACHE_TTL_STATISTICS` | `stat.ts`, `statistics.ts`                                                                                                                                               | 3600    |
-| `CACHE_TTL_MEMBERS`    | `board.ts`, `home.ts` (members)                                                                                                                                          | 3600    |
-| `CACHE_TTL_SECTIONS`   | `section.ts`                                                                                                                                                             | 3600    |
+| Variable               | Service(s)                                                                                                                                                                                      | Default |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `CACHE_TTL_NEWS`       | `news.ts`                                                                                                                                                                                       | 3600    |
+| `CACHE_TTL_VOLUMES`    | `volume.ts`                                                                                                                                                                                     | 3600    |
+| `CACHE_TTL_ARTICLES`   | `article.ts`, `section.ts`                                                                                                                                                                      | 3600    |
+| `CACHE_TTL_PAGES`      | `about.ts`, `credits.ts`, `forAuthors.ts`, `forEditors.ts`, `forReviewers.ts`, `indexing.ts`, `indexation.ts`, `acknowledgements.ts`, `forConferenceOrganisers.ts`, `proposingSpecialIssues.ts` | 3600    |
+| `CACHE_TTL_STATISTICS` | `stat.ts`, `statistics.ts`                                                                                                                                                                      | 3600    |
+| `CACHE_TTL_MEMBERS`    | `board.ts`, `home.ts` (members)                                                                                                                                                                 | 3600    |
+| `CACHE_TTL_SECTIONS`   | `section.ts`                                                                                                                                                                                    | 3600    |
+
+`services/page.ts` (`fetchPage()`) is dead code — no callers anywhere in the app — despite
+previously being listed here. Not removed from the codebase as part of this doc update;
+flagged for a future cleanup.
 
 ### Cache Tag Naming Convention
 
@@ -164,9 +176,13 @@ indexation
 pages
 └── page-{page_code}-{rvcode}     ← fine-grained page tag (e.g. page-about-epijinfo)
 
-credits / for-reviewers / for-conference-organisers /
+credits / for-reviewers / for-editors / for-conference-organisers /
 proposing-special-issues / acknowledgements
 └── {page-type}-{rvcode}          ← dedicated tag per editorial page (no home page section)
+
+editorial-workflow / ethical-charter / prepare-submission
+└── {page-type}-{rvcode}          ← the 3 for-authors/ethical-charter sub-sections
+                                     (services/forAuthors.ts), no home page section
 
 stats / statistics
 ├── stats-{rvcode}                ← home page stats block

--- a/docs/ISR_STRATEGY.md
+++ b/docs/ISR_STRATEGY.md
@@ -255,14 +255,24 @@ To make them time-based, set `CACHE_TTL_PAGES=86400` in your environment.
 
 ### Stale Content After Deployment
 
-With Valkey, the Data Cache persists across deployments. Pages will serve the
-previously cached API responses until:
+Valkey itself survives restarts, but `cache-handler.js` deliberately does **not** let
+entries survive a deployment: `_parseEntry()` compares each entry's `__buildId`
+against the current build's `BUILD_ID` and treats any mismatch as a miss — for
+**both** Full Route Cache (`PAGE`) entries and Data Cache (`FETCH`) entries. The
+same check runs as a startup sweep in `initialize()`, deleting stale entries from
+Valkey outright.
 
-- their TTL expires, or
-- a revalidation webhook is called.
+This means every deployment invalidates the entire Data Cache across all journals,
+not just the rendered HTML — the first requests after a deploy will re-fetch from
+the API for every page touched (visible in logs as a burst of `MISS`/`SET` entries
+right after rollout). This is a deliberate safety choice: if a deployment changes
+how a service transforms API data (e.g. a new expected field), a `FETCH` entry
+cached under the old build could have the old shape and cause runtime errors under
+the new code. Trading a post-deploy cache-cold-start burst for that safety margin
+is intentional — see the cache-handler.js `set()`/`_parseEntry()` comments.
 
-This is intentional (cache survives restarts). To force a full flush after a deployment,
-run `redis-cli FLUSHDB` against the Valkey master (use with caution in production).
+To force a full flush manually (e.g. outside of a deployment), run `redis-cli
+FLUSHDB` against the Valkey master (use with caution in production).
 
 ---
 

--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,14 @@ const nextConfig = {
   // Do not advertise the framework in response headers
   poweredByHeader: false,
 
+  // Deterministic build ID (git commit) instead of Next's random per-build hash.
+  // The Ansistrano preprod/prod pipeline builds independently and in parallel on
+  // each server (see deployment/ansible/deploy.yml) — a random BUILD_ID would make
+  // every server's build ID diverge, and the Valkey cache handler treats any
+  // __buildId mismatch as stale (src/lib/cache-handler.js), causing the servers to
+  // continuously invalidate each other's cache entries even for identical code.
+  generateBuildId: async () => GIT_COMMIT,
+
   env: {
     NEXT_GIT_BRANCH: GIT_BRANCH,
     NEXT_GIT_COMMIT: GIT_COMMIT,

--- a/next.config.js
+++ b/next.config.js
@@ -26,7 +26,12 @@ const nextConfig = {
   // every server's build ID diverge, and the Valkey cache handler treats any
   // __buildId mismatch as stale (src/lib/cache-handler.js), causing the servers to
   // continuously invalidate each other's cache entries even for identical code.
-  generateBuildId: async () => GIT_COMMIT,
+  //
+  // NEXT_BUILD_GIT_SHA is set by deployment/ansible/tasks/build.yml from the
+  // Ansistrano repo cache (which has .git); GIT_COMMIT (execSync above) is the
+  // fallback for local dev, where .git is present in the working directory but
+  // NOT in an Ansistrano release directory (export strategy strips it there).
+  generateBuildId: async () => process.env.NEXT_BUILD_GIT_SHA || GIT_COMMIT,
 
   env: {
     NEXT_GIT_BRANCH: GIT_BRANCH,

--- a/src/lib/__tests__/cache-handler.test.ts
+++ b/src/lib/__tests__/cache-handler.test.ts
@@ -300,7 +300,7 @@ describe('CacheHandler', () => {
       });
 
       const handler = makeHandler();
-      await handler.set('stream-key', { body: stream }, { revalidate: false, tags: [] });
+      await handler.set('stream-key', { body: stream }, { cacheControl: { revalidate: false }, tags: [] });
 
       expect(stored).toBeDefined();
       const parsed = JSON.parse(stored!);
@@ -320,7 +320,7 @@ describe('CacheHandler', () => {
   describe('set()', () => {
     it('stores entry without TTL for revalidate: false', async () => {
       const handler = makeHandler();
-      await handler.set('static-key', { html: 'test' }, { revalidate: false, tags: [] });
+      await handler.set('static-key', { html: 'test' }, { cacheControl: { revalidate: false }, tags: [] });
 
       const pipeline = mockClient._pipeline;
       // Should call set without 'EX'
@@ -334,7 +334,7 @@ describe('CacheHandler', () => {
 
     it('stores entry with TTL = revalidate * 3', async () => {
       const handler = makeHandler();
-      await handler.set('dynamic-key', { html: 'test' }, { revalidate: 3600, tags: [] });
+      await handler.set('dynamic-key', { html: 'test' }, { cacheControl: { revalidate: 3600 }, tags: [] });
 
       const pipeline = mockClient._pipeline;
       expect(pipeline.set).toHaveBeenCalledWith(
@@ -350,7 +350,7 @@ describe('CacheHandler', () => {
       await handler.set(
         'article-1',
         { html: '' },
-        { revalidate: 86400, tags: ['articles', 'journal-epijinfo'] }
+        { cacheControl: { revalidate: 86400 }, tags: ['articles', 'journal-epijinfo'] }
       );
 
       const pipeline = mockClient._pipeline;
@@ -363,7 +363,7 @@ describe('CacheHandler', () => {
     it('stores lastModified timestamp in the entry', async () => {
       const before = Date.now();
       const handler = makeHandler();
-      await handler.set('ts-key', { x: 1 }, { revalidate: false, tags: [] });
+      await handler.set('ts-key', { x: 1 }, { cacheControl: { revalidate: false }, tags: [] });
       const after = Date.now();
 
       const pipeline = mockClient._pipeline;
@@ -377,7 +377,7 @@ describe('CacheHandler', () => {
       mockClient._pipelineExec.mockRejectedValue(new Error('ECONNRESET'));
       const handler = makeHandler();
 
-      await handler.set('fallback-key', { x: 1 }, { revalidate: 60, tags: [] });
+      await handler.set('fallback-key', { x: 1 }, { cacheControl: { revalidate: 60 }, tags: [] });
 
       // Entry should be in memory cache
       const stored = _internals.memGet('data:fallback-key');
@@ -587,7 +587,7 @@ describe('CacheHandler', () => {
       expect(_internals.getCbState()).toBe(_internals.CB_STATE.OPEN);
 
       // set() should go to in-memory
-      await handler.set('open-key', { data: 'test' }, { revalidate: 60, tags: [] });
+      await handler.set('open-key', { data: 'test' }, { cacheControl: { revalidate: 60 }, tags: [] });
       const stored = _internals.memGet('data:open-key');
       expect(stored).not.toBeNull();
     });
@@ -611,7 +611,7 @@ describe('CacheHandler', () => {
 
     it('set() stores in in-memory cache', async () => {
       const handler = makeHandler();
-      await handler.set('y', { z: 1 }, { revalidate: false, tags: [] });
+      await handler.set('y', { z: 1 }, { cacheControl: { revalidate: false }, tags: [] });
       const stored = _internals.memGet('data:y');
       expect(stored).not.toBeNull();
       expect(stored?.value).toEqual({ z: 1 });

--- a/src/lib/cache-handler.js
+++ b/src/lib/cache-handler.js
@@ -391,12 +391,22 @@ class CacheHandler {
 
   /**
    * Store a cache entry.
+   *
+   * Next.js's set() context shape differs by entry kind (see
+   * SetIncrementalFetchCacheContext / SetIncrementalResponseCacheContext in
+   * node_modules/next/dist/server/response-cache/types.d.ts): FETCH entries
+   * carry only `tags` (no revalidate info at all); PAGE/route entries carry
+   * `cacheControl: { revalidate, expire }`. So `ttl` below is only ever set
+   * for page entries — fetch entries get no Redis expiry and rely on
+   * revalidateTag()/build-id mismatch for cleanup instead.
+   *
    * @param {string} key
    * @param {any} data
-   * @param {{ revalidate?: number | false, tags?: string[] }} ctx
+   * @param {{ tags?: string[], cacheControl?: { revalidate?: number | false } }} ctx
    */
   async set(key, data, ctx) {
-    const { revalidate, tags = [] } = ctx || {};
+    const tags = ctx?.tags || [];
+    const revalidate = ctx?.cacheControl?.revalidate;
     const dataKey = this._dataKey(key);
 
     const processedData = await preprocessValue(data);

--- a/src/services/forAuthors.ts
+++ b/src/services/forAuthors.ts
@@ -1,7 +1,6 @@
-import { logger } from '@/lib/logger';
 import { getJournalApiUrl } from '@/utils/env-loader';
-
-const log = logger.child({ service: 'for-authors' });
+import { safeFetchData } from '@/utils/api-error-handler';
+import { CACHE_TTL } from '@/utils/cache-ttl';
 
 export interface ForAuthorsPage {
   title: Record<string, string>;
@@ -9,80 +8,65 @@ export interface ForAuthorsPage {
   date_updated?: string;
 }
 
-/**
- * Fetch editorial workflow page content at build time
- * @param rvcode - Journal code
- * @returns Editorial workflow page data
- */
-export const fetchEditorialWorkflowPage = async (
-  rvcode: string
-): Promise<ForAuthorsPage | null> => {
+export async function fetchEditorialWorkflowPage(rvcode: string): Promise<ForAuthorsPage | null> {
   const apiUrl = getJournalApiUrl(rvcode);
-  const url = `${apiUrl}/pages?page_code=editorial-workflow&rvcode=${rvcode}`;
+  return safeFetchData<ForAuthorsPage | null>(
+    async () => {
+      const response = await fetch(
+        `${apiUrl}/pages?page_code=editorial-workflow&rvcode=${rvcode}`,
+        {
+          next: {
+            revalidate: CACHE_TTL.pages,
+            tags: ['editorial-workflow', `editorial-workflow-${rvcode}`],
+          },
+        }
+      );
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const data = await response.json();
+      return data['hydra:member']?.[0] || null;
+    },
+    null,
+    `fetchEditorialWorkflowPage(${rvcode})`
+  );
+}
 
-  try {
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      log.error(`Failed to fetch editorial workflow page: ${response.statusText}`);
-      return null;
-    }
-
-    const data = await response.json();
-    return data['hydra:member']?.[0] || null;
-  } catch (error) {
-    log.error('Error fetching editorial workflow page:', error);
-    return null;
-  }
-};
-
-/**
- * Fetch ethical charter page content at build time
- * @param rvcode - Journal code
- * @returns Ethical charter page data
- */
-export const fetchEthicalCharterPage = async (rvcode: string): Promise<ForAuthorsPage | null> => {
+export async function fetchEthicalCharterPage(rvcode: string): Promise<ForAuthorsPage | null> {
   const apiUrl = getJournalApiUrl(rvcode);
-  const url = `${apiUrl}/pages?page_code=ethical-charter&rvcode=${rvcode}`;
+  return safeFetchData<ForAuthorsPage | null>(
+    async () => {
+      const response = await fetch(`${apiUrl}/pages?page_code=ethical-charter&rvcode=${rvcode}`, {
+        next: {
+          revalidate: CACHE_TTL.pages,
+          tags: ['ethical-charter', `ethical-charter-${rvcode}`],
+        },
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const data = await response.json();
+      return data['hydra:member']?.[0] || null;
+    },
+    null,
+    `fetchEthicalCharterPage(${rvcode})`
+  );
+}
 
-  try {
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      log.error(`Failed to fetch ethical charter page: ${response.statusText}`);
-      return null;
-    }
-
-    const data = await response.json();
-    return data['hydra:member']?.[0] || null;
-  } catch (error) {
-    log.error('Error fetching ethical charter page:', error);
-    return null;
-  }
-};
-
-/**
- * Fetch prepare submission page content at build time
- * @param rvcode - Journal code
- * @returns Prepare submission page data
- */
-export const fetchPrepareSubmissionPage = async (
-  rvcode: string
-): Promise<ForAuthorsPage | null> => {
+export async function fetchPrepareSubmissionPage(rvcode: string): Promise<ForAuthorsPage | null> {
   const apiUrl = getJournalApiUrl(rvcode);
-  const url = `${apiUrl}/pages?page_code=prepare-submission&rvcode=${rvcode}`;
-
-  try {
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      return null;
-    }
-
-    const data = await response.json();
-    return data['hydra:member']?.[0] || null;
-  } catch (error) {
-    log.error('Error fetching prepare submission page:', error);
-    return null;
-  }
-};
+  return safeFetchData<ForAuthorsPage | null>(
+    async () => {
+      const response = await fetch(
+        `${apiUrl}/pages?page_code=prepare-submission&rvcode=${rvcode}`,
+        {
+          next: {
+            revalidate: CACHE_TTL.pages,
+            tags: ['prepare-submission', `prepare-submission-${rvcode}`],
+          },
+        }
+      );
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const data = await response.json();
+      return data['hydra:member']?.[0] || null;
+    },
+    null,
+    `fetchPrepareSubmissionPage(${rvcode})`
+  );
+}


### PR DESCRIPTION
## Summary
- Ansistrano builds independently and in parallel on each preprod/prod server (`deployment/ansible/deploy.yml`)
- Next.js's default random `BUILD_ID` made each server's build ID diverge even for the same commit
- The Valkey cache handler (`src/lib/cache-handler.js`) treats any `__buildId` mismatch as stale, so the two servers were continuously invalidating each other's cache entries — confirmed in preprod logs (`SET → STALE (build mismatch) → SET` loop on every request)
- Fix: `generateBuildId` in `next.config.js` now returns the git commit hash already computed by `getGitInfo()`, so independent parallel builds of the same commit produce the same `BUILD_ID`

Cherry-picked from preprod (`3a780e5`), no other preprod-only changes included.

## Test plan
- [ ] Deploy to preprod (already committed there) and confirm `STALE (build mismatch)` disappears from logs across both preprod servers
- [ ] Confirm `.next/BUILD_ID` matches on both servers after a parallel Ansistrano deploy of the same commit
- [ ] Confirm redeploying the same commit twice does not break cache (same BUILD_ID, entries preserved)